### PR TITLE
chore: スキル・ルール用シンボリックリンクの作成

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -1,0 +1,1 @@
+../../rules/conventions.md

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,1 @@
+../../rules/security.md

--- a/.claude/skills/git-branch-cleanup
+++ b/.claude/skills/git-branch-cleanup
@@ -1,0 +1,1 @@
+../../skills/git-branch-cleanup

--- a/.claude/skills/git-issue-start
+++ b/.claude/skills/git-issue-start
@@ -1,0 +1,1 @@
+../../skills/git-issue-start

--- a/.claude/skills/git-pr-create
+++ b/.claude/skills/git-pr-create
@@ -1,0 +1,1 @@
+../../skills/git-pr-create

--- a/.claude/skills/git-review-respond
+++ b/.claude/skills/git-review-respond
@@ -1,0 +1,1 @@
+../../skills/git-review-respond


### PR DESCRIPTION
## Summary
- `.claude/skills/` に `skills/` 配下の各スキルへのシンボリックリンクを作成（4つ）
- `.claude/rules/` に `rules/` 配下のルールファイルへのシンボリックリンクを作成（2つ）
- これにより `shared-claude-rules` リポジトリ自体でスキルやルールを参照可能になる

Closes #4

## Test plan
- [ ] `.claude/skills/` 配下のシンボリックリンクが正しいパスを指していることを確認
- [ ] `.claude/rules/` 配下のシンボリックリンクが正しいパスを指していることを確認
- [ ] スキル（例: `/git-pr-create`）がこのリポジトリ内で呼び出せることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)