### PR TITLE
feat: ISSUE_TEMPLATEのマスターテンプレートを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,43 @@
+name: Bug Report
+description: バグの報告
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: バグの内容
+      description: 何が起きているか説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: バグを再現する手順を記載してください
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する動作
+      description: 本来どう動作すべきか記載してください
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+      description: 実際にどう動作したか記載してください
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報
+      description: スクリーンショットや環境情報など
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,18 @@
+name: Chore
+description: 機能に直接関係しない雑務・設定系タスク
+labels: ["chore"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 内容
+      description: 作業内容を説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: 理由
+      description: なぜこの作業が必要か記載してください
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,18 @@
+name: Documentation
+description: ドキュメントの追加・修正
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 内容
+      description: 追加・修正したいドキュメントの内容を説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: 理由
+      description: なぜこの変更が必要か記載してください
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,25 @@
+name: Enhancement
+description: 既存機能の改善・拡張
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: 提案する機能や改善の内容を説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 動機
+      description: なぜこの機能・改善が必要か記載してください
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: 実現方法の案
+      description: 実装のアイデアがあれば記載してください
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: 新しい機能の提案
+labels: ["feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: 提案する機能の内容を説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 動機
+      description: なぜこの機能が必要か記載してください
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: 実現方法の案
+      description: 実装のアイデアがあれば記載してください
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- conventions.mdの種類ラベル（bug, feature, enhancement, documentation, chore）に対応する5つのYAMLフォーム形式テンプレートを`.github/ISSUE_TEMPLATE/`に追加
- personal-toolsの現行テンプレートをベースとし、ラベル体系との整合性を確認済み

Closes #15

## Test plan
- [ ] 各YAMLファイルがGitHub Issue Forms形式として正しいこと
- [ ] labelsがconventions.mdの種類ラベルと一致していること
- [ ] GitHubのIssue作成画面でテンプレートが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)