### PR TITLE
enhance: config-shared-syncをconfig-claude-syncにリネーム

### DIFF
--- a/.claude/skills/config-claude-sync
+++ b/.claude/skills/config-claude-sync
@@ -1,0 +1,1 @@
+../../skills/config-claude-sync

--- a/.claude/skills/config-shared-sync
+++ b/.claude/skills/config-shared-sync
@@ -1,1 +1,0 @@
-../../skills/config-shared-sync

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,7 +4,7 @@
 
 | スキル | コマンド | 説明 |
 |---|---|---|
-| `config-shared-sync` | `/config-shared-sync` | 共通ルール・スキルの差分検出・シンボリックリンク同期 |
+| `config-claude-sync` | `/config-claude-sync` | `.claude/`配下（rules, skills）の差分検出・シンボリックリンク同期 |
 | `git-branch-cleanup` | `/git-branch-cleanup` | ローカルブランチクリーンアップ（main切替・ブランチ削除・pull） |
 | `git-issue-create` | `/git-issue-create` | 会話の文脈からIssue作成（タイトル・本文・ラベル推定・プレビュー） |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Issue取得・ラベル検証・ブランチ作成・Plan Mode移行 |

--- a/skills/config-claude-sync/SKILL.md
+++ b/skills/config-claude-sync/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: config-shared-sync
+name: config-claude-sync
 description: Sync shared rules and skills from shared-claude-rules repository - detect missing symlinks and create them
 ---
 


### PR DESCRIPTION
## Summary
- `skills/config-shared-sync/` → `skills/config-claude-sync/` にリネーム
- SKILL.mdの`name`フィールドを更新
- `.claude/skills/`のシンボリックリンクを更新
- `skills/README.md`のエントリを更新
- personal-tools, card-gamesの`.claude/skills/`シンボリックリンクを更新

命名軸を「同期先ディレクトリ」で統一し、今後追加予定の`config-github-sync`との整合性を確保。

Closes #17

## Test plan
- [ ] `skills/config-claude-sync/SKILL.md` の `name` が `config-claude-sync` になっていること
- [ ] `.claude/skills/config-claude-sync` シンボリックリンクが正しいパスを指していること
- [ ] personal-tools, card-games の `.claude/skills/config-claude-sync` が有効なシンボリックリンクであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)