### PR TITLE
feat: config-github-syncスキルを新規作成

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -5,6 +5,7 @@
 | スキル | コマンド | 説明 |
 |---|---|---|
 | `config-claude-sync` | `/config-claude-sync` | `.claude/`配下（rules, skills）の差分検出・シンボリックリンク同期 |
+| `config-github-sync` | `/config-github-sync` | `.github/`配下（ISSUE_TEMPLATE, workflows）の差分検出・コピー同期 |
 | `git-branch-cleanup` | `/git-branch-cleanup` | ローカルブランチクリーンアップ（main切替・ブランチ削除・pull） |
 | `git-issue-create` | `/git-issue-create` | 会話の文脈からIssue作成（タイトル・本文・ラベル推定・プレビュー） |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Issue取得・ラベル検証・ブランチ作成・Plan Mode移行 |

--- a/skills/config-github-sync/SKILL.md
+++ b/skills/config-github-sync/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: config-github-sync
+description: Sync .github files (ISSUE_TEMPLATE, workflows) from shared-claude-rules repository - detect diffs and copy files
+---
+
+# GitHub Config Sync Skill
+
+shared-claude-rulesリポジトリの `.github/` 配下の共有資材（ISSUE_TEMPLATE、workflows）を現在のプロジェクトにコピーベースで同期する。GitHubがシンボリックリンクを認識しないため、ファイルコピーで同期する。
+
+## 処理手順
+
+### Step 1: 共通リポジトリの特定
+
+1. `.claude/rules/shared/` および `.claude/skills/` 配下のシンボリックリンクを探索する
+2. 見つかったシンボリックリンクの `readlink` 結果からshared-claude-rulesリポジトリのパスを解決する
+   - ルールのリンク例: `../../../shared-claude-rules/rules/conventions.md` → `shared-claude-rules` のパスを抽出
+   - スキルのリンク例: `../../shared-claude-rules/skills/git-pr-create` → `shared-claude-rules` のパスを抽出
+3. シンボリックリンクが1つも見つからない場合 → エラーを表示して終了する:
+   ```
+   エラー: shared-claude-rulesへのシンボリックリンクが見つかりません。
+   最初のセットアップはREADMEの手順に従って手動で行ってください。
+   ```
+4. 解決したパスに `.github/` ディレクトリが存在することを検証する
+   - 存在しない場合 → エラーを表示して終了する
+
+### Step 2: 差分の検出
+
+1. shared側の `.github/ISSUE_TEMPLATE/` と `.github/workflows/` を走査する
+2. ローカルの対応ファイルと比較し、各ファイルの状態を判定する:
+   - **同一**: 内容が一致（`diff -q` で判定）
+   - **差分あり**: 両方に存在するが内容が異なる
+   - **新規**: shared側にあるがローカルに存在しない
+   - **ローカルのみ**: ローカルにあるがshared側に存在しない（警告表示のみ、削除はしない）
+
+### Step 3: 差分の提示・ユーザー確認
+
+1. すべて同一の場合 → 以下を表示して終了する:
+   ```
+   .github/ 配下のファイルはすべて同期済みです。
+   ```
+2. 差分がある場合、カテゴリ別に状態を一覧表示する:
+   ```
+   ## .github 同期チェック
+
+   ### ISSUE_TEMPLATE
+   - bug.yml — 同一 ✓
+   - chore.yml — ローカルに存在しない（新規追加）
+   - enhancement.yml — 差分あり
+
+   ### workflows
+   - ci.yml — 差分あり
+
+   同期する項目を選択してください（例: 全て / ISSUE_TEMPLATEのみ）。
+   差分の詳細を確認したい場合はお知らせください。
+   ```
+3. ユーザーが差分詳細を要求した場合 → `diff` 出力を表示する
+4. ユーザーの回答に応じて同期対象を決定する:
+   - 全承認 → 全項目を同期する
+   - 一部除外を指示 → 指示されたものを除外して同期する
+
+### Step 4: ファイルコピー
+
+1. `.github/ISSUE_TEMPLATE/` や `.github/workflows/` ディレクトリが存在しない場合は `mkdir -p` で作成する
+2. 選択された項目を `cp` で上書きコピーする
+3. コピー後、`diff -q` で内容が一致することを検証する
+   - 不一致の場合 → エラーを表示する
+
+### Step 5: 結果表示
+
+同期結果を以下の形式で表示する:
+
+```
+## 同期完了
+
+- 同期したISSUE_TEMPLATE: X件
+  - <ファイル名1>（新規追加）
+  - <ファイル名2>（更新）
+- 同期したワークフロー: X件
+  - <ファイル名1>（更新）
+```


### PR DESCRIPTION
## Summary
- `.github/`配下（ISSUE_TEMPLATE, workflows）の共有資材をコピーベースで同期する`config-github-sync`スキルを追加
- `skills/README.md`にスキル一覧を追記

Closes #18

## Test plan
- [ ] `/config-github-sync`を実行し、shared-claude-rulesリポジトリからの`.github/`同期が正常に動作することを確認
- [ ] シンボリックリンクが存在しない環境でエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)