### PR TITLE
docs: CLAUDE.md を追加しリポジトリのコンテキストを記述する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Repository Is
+
+A centralized source of shared Claude Code rules and skills distributed to consuming projects via symlinks. All consuming repositories must live in the same parent directory as this one.
+
+**Symlink pattern** (from a consuming repo):
+```bash
+ln -s ../../shared-claude-code/rules/conventions.md .claude/rules/conventions.md
+ln -s ../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
+```
+
+## Repository Structure
+
+```
+rules/          # Master rule files (English) — symlinked into .claude/rules/ of consuming repos
+skills/         # Master skill definitions — symlinked into .claude/skills/ of consuming repos
+  README.md     # Skills index table — must be updated when adding a skill
+.github/
+  ISSUE_TEMPLATE/   # 5 issue templates (Japanese)
+  workflows/ci.yml  # CI: eol-check → lint → test → build
+docs/ja-JP/     # Japanese translations (supplementary, not authoritative)
+.claude/
+  rules/        # Symlinks → ../../rules/
+  skills/       # Symlinks → ../../skills/
+```
+
+## Adding a New Skill
+
+1. Create `skills/<category>-<object>-<verb>/SKILL.md` with YAML frontmatter (`name`, `description`)
+2. Add a symlink: `.claude/skills/<name> -> ../../skills/<name>`
+3. Update `skills/README.md` with a row in the skills table
+4. Add Japanese translation at `docs/ja-JP/skills/<name>/SKILL.md`

--- a/docs/ja-JP/CLAUDE.md
+++ b/docs/ja-JP/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+このファイルは、このリポジトリで作業する Claude Code (claude.ai/code) へのガイダンスを提供します。
+
+## このリポジトリについて
+
+シンボリックリンクを通じて複数のプロジェクトへ配布する、Claude Code の共通ルールとスキルの集約リポジトリです。すべての消費リポジトリは、このリポジトリと同じ親ディレクトリに配置する必要があります。
+
+**シンボリックリンクの作成例**（消費リポジトリ側で実行）:
+```bash
+ln -s ../../shared-claude-code/rules/conventions.md .claude/rules/conventions.md
+ln -s ../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
+```
+
+## ディレクトリ構成
+
+```
+rules/          # マスタールールファイル（英語） — 消費リポジトリの .claude/rules/ にシンボリックリンク
+skills/         # マスタースキル定義 — 消費リポジトリの .claude/skills/ にシンボリックリンク
+  README.md     # スキル一覧テーブル — スキル追加時に更新必須
+.github/
+  ISSUE_TEMPLATE/   # Issue テンプレート 5種（日本語）
+  workflows/ci.yml  # CI: eol-check → lint → test → build
+docs/ja-JP/     # 日本語翻訳（補足資料。英語版が正）
+.claude/
+  rules/        # シンボリックリンク → ../../rules/
+  skills/       # シンボリックリンク → ../../skills/
+```
+
+## 新しいスキルの追加手順
+
+1. `skills/<category>-<object>-<verb>/SKILL.md` を YAML フロントマター（`name`, `description`）付きで作成
+2. シンボリックリンクを追加: `.claude/skills/<name> -> ../../skills/<name>`
+3. `skills/README.md` のスキル一覧テーブルに行を追加
+4. `docs/ja-JP/skills/<name>/SKILL.md` に日本語翻訳を追加


### PR DESCRIPTION
## Summary
- リポジトリの目的・構成・シンボリックリンク構成・スキル追加手順を記述した `CLAUDE.md` を新規作成
- `docs/ja-JP/CLAUDE.md` に日本語版を作成（英語版との同期運用）

Closes #37

## Test plan
- [ ] `CLAUDE.md` がリポジトリルートに存在すること
- [ ] リポジトリの目的・ディレクトリ構成・シンボリックリンク構成・スキル追加手順が記述されていること
- [ ] `docs/ja-JP/CLAUDE.md` に日本語版が存在すること
- [ ] `shared-claude-rules` の文字列が含まれていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)