### PR TITLE
docs: README.md のスキル一覧・使用例を7スキル対応に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ rules/
 ├── conventions.md          # Development conventions
 └── security.md             # Security rules
 skills/
+├── config-claude-sync/     # Sync shared rules/skills from shared-claude-code via symlinks
+├── config-github-sync/     # Sync .github files from shared-claude-code via file copy
 ├── git-branch-cleanup/     # Local branch cleanup after PR merge
+├── git-issue-create/       # Create GitHub Issue from conversation context
 ├── git-issue-start/        # Start workflow from GitHub Issue
 ├── git-pr-create/          # Create GitHub PR with analysis
 └── git-review-respond/     # Respond to PR review comments
@@ -23,7 +26,10 @@ Each consuming repository creates symlinks from `.claude/rules/` and `.claude/sk
 # From the consuming repository root
 ln -s ../../shared-claude-code/rules/conventions.md .claude/rules/conventions.md
 ln -s ../../shared-claude-code/rules/security.md .claude/rules/security.md
+ln -s ../../shared-claude-code/skills/config-claude-sync .claude/skills/config-claude-sync
+ln -s ../../shared-claude-code/skills/config-github-sync .claude/skills/config-github-sync
 ln -s ../../shared-claude-code/skills/git-branch-cleanup .claude/skills/git-branch-cleanup
+ln -s ../../shared-claude-code/skills/git-issue-create .claude/skills/git-issue-create
 ln -s ../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
 ln -s ../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
 ln -s ../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -9,7 +9,10 @@ rules/
 ├── conventions.md          # 開発規約
 └── security.md             # セキュリティルール
 skills/
+├── config-claude-sync/     # shared-claude-codeからルール・スキルをシンボリックリンクで同期
+├── config-github-sync/     # shared-claude-codeから.githubファイルをコピーで同期
 ├── git-branch-cleanup/     # PRマージ後のローカルブランチクリーンアップ
+├── git-issue-create/       # 会話コンテキストからGitHub Issueを作成
 ├── git-issue-start/        # GitHub Issueからの作業開始ワークフロー
 ├── git-pr-create/          # 分析付きGitHub PR作成
 └── git-review-respond/     # PRレビューコメントへの対応
@@ -23,7 +26,10 @@ skills/
 # 対象リポジトリのルートから実行
 ln -s ../../shared-claude-code/rules/conventions.md .claude/rules/conventions.md
 ln -s ../../shared-claude-code/rules/security.md .claude/rules/security.md
+ln -s ../../shared-claude-code/skills/config-claude-sync .claude/skills/config-claude-sync
+ln -s ../../shared-claude-code/skills/config-github-sync .claude/skills/config-github-sync
 ln -s ../../shared-claude-code/skills/git-branch-cleanup .claude/skills/git-branch-cleanup
+ln -s ../../shared-claude-code/skills/git-issue-create .claude/skills/git-issue-create
 ln -s ../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
 ln -s ../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
 ln -s ../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond


### PR DESCRIPTION
## Summary
- `config-claude-sync`、`config-github-sync`、`git-issue-create` の3スキルを Structure セクションに追加
- Usage セクションのシンボリックリンク例を7スキルすべて対応に更新
- `docs/ja-JP/README.md` も同様に更新

Closes #38

## Test plan
- [ ] `README.md` の Structure セクションに全7スキルが記載されていること
- [ ] `README.md` の Usage セクションに全7スキルのシンボリックリンク例があること
- [ ] `docs/ja-JP/README.md` も同様に更新されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)