### PR TITLE
enhance: config-github-sync に ci-templates 同期機能を追加

### DIFF
--- a/docs/ja-JP/skills/config-github-sync/SKILL.md
+++ b/docs/ja-JP/skills/config-github-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: config-github-sync
-description: Sync .github files (ISSUE_TEMPLATE, workflows) from shared-claude-code repository - detect diffs and copy files
+description: Sync .github files and ci-templates from shared-claude-code repository - detect language, present diffs, and copy files
 ---
 
 # GitHub Config Sync Skill
@@ -65,7 +65,55 @@ shared-claude-codeリポジトリの `.github/` 配下の共有資材（ISSUE_TE
 3. コピー後、`diff -q` で内容が一致することを検証する
    - 不一致の場合 → エラーを表示する
 
-### Step 5: 結果表示
+### Step 5: CI テンプレート同期
+
+1. shared リポジトリに `ci-templates/` ディレクトリが存在するか確認する。存在しない場合はこのステップをスキップする。
+2. **プロジェクトの言語/フレームワークを推定する**（ローカルのプロジェクトルートを確認）:
+   - `package.json` あり → Node.js 系。`dependencies.next` または `devDependencies.next` があれば **Next.js** と判定
+   - `pyproject.toml` または `setup.py` あり → **Python**
+   - `go.mod` あり → **Go**
+   - `ci-templates/` 配下の利用可能なテンプレートディレクトリも候補として列挙する
+3. **候補を提示してユーザーに確認する**:
+   ```
+   ## CI テンプレート同期
+
+   推定フレームワーク: Next.js（package.json の dependencies.next を検出）
+
+   利用可能なテンプレート:
+   - nextjs（推奨）
+
+   同期するテンプレートを選択してください（スキップする場合は「スキップ」と入力）。
+   ```
+   - 一致するテンプレートがない場合 → 利用可能なテンプレートを表示し、選択またはスキップを促す
+4. **選択されたテンプレートの差分を検出する**:
+   - `ci-templates/<lang>/.github/workflows/ci.yml` ↔ ローカルの `.github/workflows/ci.yml`
+   - `ci-templates/<lang>/` 直下の各ファイル（`.github/` 以外）↔ ローカルのプロジェクトルートの同名ファイル
+   - 各ファイルを **同一**・**差分あり**・**新規**・**ローカルのみ** に分類（Step 2 と同じ基準）
+5. **差分を提示してユーザーに確認する**:
+   - すべて同一の場合 → 「CI テンプレートのファイルはすべて同期済みです。」と表示してコピーをスキップ
+   - 差分がある場合、カテゴリ別に状態を一覧表示する:
+     ```
+     ### CI テンプレート（nextjs）
+     #### .github/workflows
+     - ci.yml — 差分あり
+
+     #### プロジェクトルート
+     - package.json — ローカルに存在しない（新規追加）
+     - tsconfig.json — 差分あり
+     - jest.config.mjs — 同一 ✓
+
+     同期する項目を選択してください（例: 全て / ci.ymlのみ）。
+     差分の詳細を確認したい場合はお知らせください。
+     ```
+   - ユーザーが差分詳細を要求した場合 → `diff` 出力を表示する
+   - ユーザーの回答に応じて同期対象を決定する
+6. **ファイルをコピーする**:
+   - コピー先ディレクトリが存在しない場合は `mkdir -p` で作成する
+   - 選択されたファイルを `cp` で上書きコピーする
+   - コピー後、`diff -q` で内容が一致することを検証する
+     - 不一致の場合 → エラーを表示する
+
+### Step 6: 結果表示
 
 同期結果を以下の形式で表示する:
 
@@ -77,4 +125,9 @@ shared-claude-codeリポジトリの `.github/` 配下の共有資材（ISSUE_TE
   - <ファイル名2>（更新）
 - 同期したワークフロー: X件
   - <ファイル名1>（更新）
+- 同期したCIテンプレート（<lang>）: X件
+  - .github/workflows/ci.yml（更新）
+  - tsconfig.json（新規追加）
 ```
+
+CI テンプレートを同期しなかった場合は、該当行を省略する。

--- a/skills/config-github-sync/SKILL.md
+++ b/skills/config-github-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: config-github-sync
-description: Sync .github files (ISSUE_TEMPLATE, workflows) from shared-claude-code repository - detect diffs and copy files
+description: Sync .github files and ci-templates from shared-claude-code repository - detect language, present diffs, and copy files
 ---
 
 # GitHub Config Sync Skill
@@ -65,7 +65,55 @@ Sync shared assets under `.github/` (ISSUE_TEMPLATE, workflows) from the shared-
 3. After copying, verify contents match with `diff -q`
    - If mismatch → display error
 
-### Step 5: Display Results
+### Step 5: CI Template Sync
+
+1. Check whether the `ci-templates/` directory exists in the shared repository. If it does not exist, skip this step.
+2. **Detect the project language/framework** from the local project root:
+   - `package.json` present → Node.js family. If `dependencies.next` or `devDependencies.next` is found → **Next.js**
+   - `pyproject.toml` or `setup.py` present → **Python**
+   - `go.mod` present → **Go**
+   - List available template directories under `ci-templates/` as additional candidates
+3. **Present candidates and confirm with the user**:
+   ```
+   ## CI テンプレート同期
+
+   推定フレームワーク: Next.js（package.json の dependencies.next を検出）
+
+   利用可能なテンプレート:
+   - nextjs（推奨）
+
+   同期するテンプレートを選択してください（スキップする場合は「スキップ」と入力）。
+   ```
+   - If no matching template is found → display available templates and ask the user to choose or skip
+4. **Detect differences** for the selected template:
+   - `ci-templates/<lang>/.github/workflows/ci.yml` vs local `.github/workflows/ci.yml`
+   - Each file directly under `ci-templates/<lang>/` (non-`.github/` items) vs the same filename at the local project root
+   - Categorize each file as **Identical**, **Differs**, **New**, or **Local only** (same criteria as Step 2)
+5. **Present differences and confirm with the user**:
+   - If all files are identical → display "CI テンプレートのファイルはすべて同期済みです。" and skip copying
+   - If differences exist, display by category:
+     ```
+     ### CI テンプレート（nextjs）
+     #### .github/workflows
+     - ci.yml — 差分あり
+
+     #### プロジェクトルート
+     - package.json — ローカルに存在しない（新規追加）
+     - tsconfig.json — 差分あり
+     - jest.config.mjs — 同一 ✓
+
+     同期する項目を選択してください（例: 全て / ci.ymlのみ）。
+     差分の詳細を確認したい場合はお知らせください。
+     ```
+   - If the user requests diff details → show `diff` output
+   - Determine sync targets based on the user's response
+6. **Copy files**:
+   - Create destination directories with `mkdir -p` if they do not exist
+   - Overwrite-copy selected files with `cp`
+   - After copying, verify contents match with `diff -q`
+     - If mismatch → display error
+
+### Step 6: Display Results
 
 Display sync results in the following format:
 
@@ -77,4 +125,9 @@ Display sync results in the following format:
   - <ファイル名2>（更新）
 - 同期したワークフロー: X件
   - <ファイル名1>（更新）
+- 同期したCIテンプレート（<lang>）: X件
+  - .github/workflows/ci.yml（更新）
+  - tsconfig.json（新規追加）
 ```
+
+CI テンプレートを同期しなかった場合は、該当行を省略する。


### PR DESCRIPTION
## Summary
- `config-github-sync` スキルに Step 5（CI テンプレート同期）を追加
- `package.json` / `pyproject.toml` / `go.mod` からプロジェクトの言語/フレームワークを自動推定し、`ci-templates/` 内の候補を提示
- ユーザーが選択したテンプレートの `ci.yml` およびルート設定ファイル群をプロジェクトへコピー
- 既存の `.github/ISSUE_TEMPLATE` / `workflows` 同期フロー（Step 1〜4）は変更なし
- 英語版・日本語版 SKILL.md を同時更新

Closes #42

## Test plan
- [ ] スキル説明文（frontmatter description）に ci-templates への言及が含まれること
- [ ] Step 5 が言語推定 → 候補提示 → ユーザー選択 → コピー → 検証のフローを正しく記述していること
- [ ] `ci-templates/` がない場合はスキップする旨が記載されていること
- [ ] Step 6（結果表示）に CI テンプレート同期結果の行が追加されていること
- [ ] `docs/ja-JP/skills/config-github-sync/SKILL.md` が英語版と対応していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)