### PR TITLE
enhance: Issue作成・コメント投稿時にClaude Code署名を付与する

### DIFF
--- a/docs/ja-JP/rules/conventions.md
+++ b/docs/ja-JP/rules/conventions.md
@@ -90,7 +90,7 @@ Issue・PRのタイトルおよび本文は **日本語** で記述する。
 ClaudeがGitHub上にコメントを投稿する際は、人間のコメントと区別できるよう、コメント末尾に以下を付与する:
 
 ```
-🤖 by Claude Code
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
 ## スキル追加時のREADME更新

--- a/docs/ja-JP/skills/git-issue-create/SKILL.md
+++ b/docs/ja-JP/skills/git-issue-create/SKILL.md
@@ -50,6 +50,8 @@ description: Create a GitHub Issue from conversation context - analyze context, 
    ## 受け入れ条件
    - [ ] <条件1>
    - [ ] <条件2>
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
 
    **`documentation` / `chore` の場合:**
@@ -63,6 +65,8 @@ description: Create a GitHub Issue from conversation context - analyze context, 
    ## 受け入れ条件
    - [ ] <条件1>
    - [ ] <条件2>
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
 
 ### Step 3: プレビュー・ユーザー確認

--- a/docs/ja-JP/skills/git-review-respond/SKILL.md
+++ b/docs/ja-JP/skills/git-review-respond/SKILL.md
@@ -174,7 +174,11 @@ gh api repos/{owner}/{repo}/pulls/<PR番号>/comments \
 
 返信は日本語で記述する（レビュアーが日本語の場合）。レビューコメントが英語の場合は英語で返信する。
 
-**署名**: 共通開発規約の「GitHubコメントの署名」ルールに従い、各返信の末尾に署名を付与する。
+**署名**: 各返信本文の末尾に以下の署名を付与する:
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
 
 ### Step 10: 完了サマリー
 

--- a/rules/conventions.md
+++ b/rules/conventions.md
@@ -90,7 +90,7 @@ Issue and PR titles and bodies must be written in **Japanese**.
 When Claude posts a comment on GitHub, append the following at the end to distinguish it from human comments:
 
 ```
-🤖 by Claude Code
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
 ## Skill README Update

--- a/skills/git-issue-create/SKILL.md
+++ b/skills/git-issue-create/SKILL.md
@@ -50,6 +50,8 @@ Automate the workflow for creating GitHub Issues from conversation context. Perf
    ## 受け入れ条件
    - [ ] <条件1>
    - [ ] <条件2>
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
 
    **For `documentation` / `chore`:**
@@ -63,6 +65,8 @@ Automate the workflow for creating GitHub Issues from conversation context. Perf
    ## 受け入れ条件
    - [ ] <条件1>
    - [ ] <条件2>
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
 
 ### Step 3: Preview and User Confirmation

--- a/skills/git-review-respond/SKILL.md
+++ b/skills/git-review-respond/SKILL.md
@@ -174,7 +174,11 @@ Reply content guidelines:
 
 Write replies in Japanese (when the reviewer uses Japanese). If the review comment is in English, reply in English.
 
-**Signature**: Follow the "GitHub Comment Signature" rule in the shared development conventions, appending a signature at the end of each reply.
+**Signature**: Append the following signature at the end of each reply body:
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
 
 ### Step 10: Completion Summary
 


### PR DESCRIPTION
## Summary
- `rules/conventions.md` の署名フォーマットを `🤖 by Claude Code` から `🤖 Generated with [Claude Code](https://claude.com/claude-code)` に統一
- `git-issue-create` スキルの Issue 本文テンプレートに署名を直接追加
- `git-review-respond` スキルの返信テンプレートの署名を間接参照（conventions 参照）から直接埋め込みに変更
- 上記3点を日本語版（`docs/ja-JP/`）にも反映

Closes #40

## Test plan
- [ ] `conventions.md` の "GitHub Comment Signature" セクションが統一フォーマットになっていることを確認
- [ ] `git-issue-create/SKILL.md` の全 Issue 本文テンプレートに署名が含まれることを確認
- [ ] `git-review-respond/SKILL.md` の返信テンプレートに署名が直接埋め込まれていることを確認
- [ ] 日本語版（`docs/ja-JP/`）が英語版と対応していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)