### PR TITLE
chore: SKILL.md内の日本語メッセージを英語に統一

### DIFF
--- a/skills/config-claude-sync/SKILL.md
+++ b/skills/config-claude-sync/SKILL.md
@@ -17,8 +17,8 @@ Sync shared rules and skills from the shared-claude-code repository to the curre
    - Skill link example: `../../shared-claude-code/skills/git-pr-create` → extract `shared-claude-code` path
 3. If no symlinks are found → display error and exit:
    ```
-   エラー: shared-claude-codeへのシンボリックリンクが見つかりません。
-   最初のセットアップはREADMEの手順に従って手動で行ってください。
+   Error: No symlinks to shared-claude-code found.
+   Initial setup must be done manually following the README instructions.
    ```
 4. Verify that `rules/` and `skills/` directories exist at the resolved path
    - If they do not exist → display error and exit
@@ -35,21 +35,21 @@ Sync shared rules and skills from the shared-claude-code repository to the curre
 
 1. If everything is already synced → display the following and exit:
    ```
-   すべてのルール・スキルは同期済みです。
+   All rules and skills are already synced.
    ```
 2. If there are missing items, display in the following format:
    ```
-   ## 未同期の項目
+   ## Unsynced Items
 
-   ### ルール
+   ### Rules
    - conventions.md
    - security.md
 
-   ### スキル
+   ### Skills
    - git-branch-cleanup
    - git-issue-create
 
-   上記の項目を同期しますか？除外したい項目があればお知らせください。
+   Would you like to sync these items? Let me know if you want to exclude any.
    ```
 3. Branch based on the user's response:
    - Full approval → sync all items
@@ -63,7 +63,7 @@ Sync shared rules and skills from the shared-claude-code repository to the curre
    - Check for uncommitted changes with `git status --porcelain`
      - If changes exist → display error and exit:
        ```
-       エラー: mainブランチに未コミットの変更があります。変更をコミットまたはスタッシュしてから再実行してください。
+       Error: There are uncommitted changes on the main branch. Please commit or stash the changes and run again.
        ```
    - Check if a branch with the same name exists with `git branch --list chore/sync-claude-rules`
      - If it does not exist → create branch with `git checkout -b chore/sync-claude-rules`
@@ -93,19 +93,19 @@ Sync shared rules and skills from the shared-claude-code repository to the curre
 Display sync results in the following format:
 
 ```
-## 同期完了
+## Sync Complete
 
-- ブランチ: <ブランチ名>（新規作成 / 既存）
-- コミット: <コミットハッシュ短縮>
-- 同期したルール: X件
-  - <ファイル名1>
-  - <ファイル名2>
-- 同期したスキル: X件
-  - <スキル名1>
-  - <スキル名2>
+- Branch: <branch name> (newly created / existing)
+- Commit: <short commit hash>
+- Synced rules: X
+  - <filename 1>
+  - <filename 2>
+- Synced skills: X
+  - <skill name 1>
+  - <skill name 2>
 
-`/git-pr-create` でPRを作成できます。
+You can create a PR with `/git-pr-create`.
 ```
 
-- Display "`/git-pr-create` でPRを作成できます。" only when a new branch was created in Step 4
-- If running on a branch other than main, display "既存" and omit the PR suggestion
+- Display "You can create a PR with `/git-pr-create`." only when a new branch was created in Step 4
+- If running on a branch other than main, display "existing" and omit the PR suggestion

--- a/skills/git-issue-create/SKILL.md
+++ b/skills/git-issue-create/SKILL.md
@@ -38,33 +38,33 @@ Automate the workflow for creating GitHub Issues from conversation context. Perf
 
    **For `feature` / `enhancement` / `bug`:**
    ```
-   ## 概要
-   <1-2文で変更の目的を説明>
+   ## Overview
+   <Describe the purpose of the change in 1-2 sentences>
 
-   ## 背景・動機
-   <なぜこの変更が必要か>
+   ## Background & Motivation
+   <Why is this change needed>
 
-   ## 実装方針
-   <技術的なアプローチの概要>
+   ## Implementation Approach
+   <Technical approach overview>
 
-   ## 受け入れ条件
-   - [ ] <条件1>
-   - [ ] <条件2>
+   ## Acceptance Criteria
+   - [ ] <criteria 1>
+   - [ ] <criteria 2>
 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
 
    **For `documentation` / `chore`:**
    ```
-   ## 概要
-   <1-2文で変更の目的を説明>
+   ## Overview
+   <Describe the purpose of the change in 1-2 sentences>
 
-   ## 背景・動機
-   <なぜこの変更が必要か>
+   ## Background & Motivation
+   <Why is this change needed>
 
-   ## 受け入れ条件
-   - [ ] <条件1>
-   - [ ] <条件2>
+   ## Acceptance Criteria
+   - [ ] <criteria 1>
+   - [ ] <criteria 2>
 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
@@ -74,17 +74,17 @@ Automate the workflow for creating GitHub Issues from conversation context. Perf
 Display a preview in the following format and obtain user approval:
 
 ```
-## Issueプレビュー
+## Issue Preview
 
-**タイトル**: <タイトル>
-**種類ラベル**: <ラベル>
-**優先度ラベル**: <ラベル>
+**Title**: <title>
+**Type Label**: <label>
+**Priority Label**: <label>
 
 ---
-<本文>
+<body>
 ---
 
-この内容でIssueを作成してよろしいですか？修正点があればお知らせください。
+Shall I create the Issue with this content? Let me know if you'd like any changes.
 ```
 
 - If the user approves → proceed to Step 4
@@ -94,8 +94,8 @@ Display a preview in the following format and obtain user approval:
 
 1. Create the Issue using `gh issue create`:
    ```
-   gh issue create --title "<タイトル>" --label "<種類ラベル>" --label "<優先度ラベル>" --body "$(cat <<'EOF'
-   <本文>
+   gh issue create --title "<title>" --label "<type label>" --label "<priority label>" --body "$(cat <<'EOF'
+   <body>
    EOF
    )"
    ```
@@ -106,11 +106,11 @@ Display a preview in the following format and obtain user approval:
 Display the creation results in the following format:
 
 ```
-## Issue作成完了
+## Issue Created
 
-Issue #XX: <タイトル>
+Issue #XX: <title>
 <Issue URL>
 
-- 種類ラベル: <種類ラベル>
-- 優先度ラベル: <優先度ラベル>
+- Type Label: <type label>
+- Priority Label: <priority label>
 ```

--- a/skills/git-pr-create/SKILL.md
+++ b/skills/git-pr-create/SKILL.md
@@ -12,13 +12,13 @@ Automate the workflow for creating a GitHub PR from the current branch. Performs
 ### Step 1: Check Prerequisites
 
 1. Get the current branch with `git branch --show-current`
-   - If on `main` → display "エラー: mainブランチ上ではPRを作成できません。作業ブランチに切り替えてください。" and exit
+   - If on `main` → display "Error: Cannot create a PR on the main branch. Please switch to a working branch." and exit
 2. Check for existing PRs with `gh pr list --head <branch name> --json number,url,state`
-   - If an `OPEN` PR exists → display "エラー: このブランチには既にオープンなPRがあります: <URL>" and exit
+   - If an `OPEN` PR exists → display "Error: This branch already has an open PR: <URL>" and exit
 3. Check for uncommitted changes with `git status --porcelain`
    - If changes exist → analyze the changes, stage related files individually with `git add <file path>`, generate an appropriate commit message and `git commit` (do not use `git add -A` or `git add .`; for untracked files, judge relevance to the changes and exclude unrelated ones)
 4. Verify commits exist with `git log main..HEAD --oneline`
-   - If no commits → display "エラー: mainブランチからのコミットがありません。" and exit
+   - If no commits → display "Error: No commits from the main branch." and exit
 5. Push the branch to remote:
    - Run `git push -u origin <branch name>`
    - If it fails, display the error and exit
@@ -74,8 +74,8 @@ From the diff file list in `git diff main...HEAD --name-only`, detect changes th
 3. **Handling based on results**:
    - **Inconsistency detected**: Display a warning in the following format and continue (do not block PR creation):
      ```
-     ⚠️ ドキュメント整合性チェック:
-     - <検出内容>: <対象ドキュメント>の更新が必要な可能性があります
+     ⚠️ Documentation Consistency Check:
+     - <detection>: <target document> may need to be updated
      ```
    - **No detection patterns matched**: Proceed to Step 6 without displaying anything
 
@@ -86,13 +86,13 @@ From the diff file list in `git diff main...HEAD --name-only`, detect changes th
 
    ```
    ## Summary
-   - <変更の要点1>
-   - <変更の要点2>
+   - <key change 1>
+   - <key change 2>
 
-   Closes #XX  ← Issue特定時のみ
+   Closes #XX  ← only when Issue is identified
 
    ## Test plan
-   - [ ] <テスト項目>
+   - [ ] <test item>
 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
@@ -100,8 +100,8 @@ From the diff file list in `git diff main...HEAD --name-only`, detect changes th
 3. Create the PR with `gh pr create --base main --title "..." --body "..."`
    - Use a heredoc for the body to preserve formatting:
      ```
-     gh pr create --base main --title "<タイトル>" --body "$(cat <<'EOF'
-     <本文>
+     gh pr create --base main --title "<title>" --body "$(cat <<'EOF'
+     <body>
      EOF
      )"
      ```
@@ -112,12 +112,12 @@ From the diff file list in `git diff main...HEAD --name-only`, detect changes th
 Display the creation results in the following format:
 
 ```
-## PR作成完了
+## PR Created
 
-PR #XX: <タイトル>
+PR #XX: <title>
 <PR URL>
 
-- 対応Issue: #XX <Issueタイトル>  ← Issue特定時のみ
-- 変更ファイル数: X件
-- 変更行数: +XX / -XX
+- Related Issue: #XX <Issue title>  ← only when Issue is identified
+- Files changed: X
+- Lines changed: +XX / -XX
 ```

--- a/skills/git-review-respond/SKILL.md
+++ b/skills/git-review-respond/SKILL.md
@@ -15,11 +15,11 @@ Fetch and analyze GitHub PR review comments, then perform code fixes, commits, a
 - If `$ARGUMENTS` is specified as a number, use that PR number
 - If not specified or not a number, ask the user for the PR number:
   ```
-  対応するPRの番号を教えてください。
+  Please provide the PR number you'd like to address.
   ```
 - If a clear number cannot be determined from the user's response, exit with an error. Do not guess or make ambiguous interpretations:
   ```
-  エラー: PR番号を特定できませんでした。数値で指定してください。
+  Error: Could not identify the PR number. Please specify a number.
   ```
 
 ### Step 2: Fetch PR Information and Switch Branch
@@ -28,14 +28,14 @@ Fetch and analyze GitHub PR review comments, then perform code fixes, commits, a
 2. If the command fails (no PR exists for the given number):
    - Check if it exists as an Issue with `gh issue view <PR number>`, and if it's an Issue, display the following and exit:
      ```
-     エラー: #XX はIssueです。PRの番号を指定してください。
+     Error: #XX is an Issue. Please specify a PR number.
      ```
    - If it's not an Issue either, display the following and exit:
      ```
-     エラー: PR #XX は存在しません。
+     Error: PR #XX does not exist.
      ```
 3. Check the PR's `state`:
-   - If not `OPEN` → warn with "このPRは既にクローズ/マージされています" and exit
+   - If not `OPEN` → warn with "This PR is already closed/merged." and exit
 4. Checkout the PR's `headRefName` branch:
    - Run `git checkout <headRefName>`
    - Pull the latest from remote with `git pull`
@@ -71,7 +71,7 @@ Fetch and analyze GitHub PR review comments, then perform code fixes, commits, a
    - Comments with `in_reply_to_id` set (reply comments)
    - Comments belonging to resolved threads
 
-4. If 0 target comments remain → display "対応すべきレビューコメントはありません" and exit
+4. If 0 target comments remain → display "There are no review comments to address." and exit
 
 ### Step 4: Analyze and Classify Each Comment
 
@@ -105,27 +105,27 @@ After applying these criteria, classify each comment into one of the following:
 Display the classification results in the following format and wait for user approval:
 
 ```
-## PRレビューコメント分析結果
+## PR Review Comment Analysis
 
-PR #XX: <タイトル>
-対象コメント: X件
+PR #XX: <title>
+Target comments: X
 
-### 要修正 (X件)
+### Needs fix (X)
 1. `path/to/file.ts:L42` - @reviewer
-   > コメント内容の要約
-   → 修正方針: ～を変更する
+   > Summary of comment
+   → Fix approach: change ~
 
-### 要説明 (X件)
+### Needs response (X)
 1. `path/to/file.ts:L10` - @reviewer
-   > コメント内容の要約
-   → 回答方針: ～について説明する
+   > Summary of comment
+   → Response approach: explain ~
 
-### 対応不要 (X件)
+### No action needed (X)
 1. `path/to/file.ts:L5` - @reviewer
-   > コメント内容の要約
-   → 理由: 称賛コメント
+   > Summary of comment
+   → Reason: praise comment
 
-この内容で対応を進めてよいですか？
+Shall I proceed with these?
 ```
 
 **Wait for user approval before proceeding to the next step.** If the user changes the classification or approach, follow their direction.
@@ -163,12 +163,12 @@ Reply to each comment using `gh api`. Post replies in the same thread as the ori
 ```
 gh api repos/{owner}/{repo}/pulls/<PR number>/comments \
   -method POST \
-  -f body="<返信内容>" \
-  -F in_reply_to=<元コメントのID>
+  -f body="<reply body>" \
+  -F in_reply_to=<original comment ID>
 ```
 
 Reply content guidelines:
-- **Needs fix (fixed)**: Briefly explain the fix (e.g., "修正しました。`xxx` を `yyy` に変更しています。")
+- **Needs fix (fixed)**: Briefly explain the fix (e.g., "Fixed. Changed `xxx` to `yyy`.")
 - **Needs response**: Write the answer to the question
 - **No action needed**: Explain the reason if needed, or reply with thanks
 
@@ -185,15 +185,15 @@ Write replies in Japanese (when the reviewer uses Japanese). If the review comme
 Display the results in the following format:
 
 ```
-## 完了サマリー
+## Completion Summary
 
-PR #XX: <タイトル>
+PR #XX: <title>
 <PR URL>
 
-- 修正済み: X件
-- 説明返信: X件
-- 対応不要: X件
-- スキップ: X件（理由: ファイル削除済みなど）
+- Fixed: X
+- Explained: X
+- No action needed: X
+- Skipped: X (reason: file deleted, etc.)
 
-コミット: <コミットハッシュ>
+Commit: <commit hash>
 ```


### PR DESCRIPTION
## Summary
- `skills/` 配下の4ファイル（config-claude-sync、git-issue-create、git-pr-create、git-review-respond）に残っていたコードブロック内の日本語テキストをすべて英語に置き換えた
- エラーメッセージ・確認プロンプト・出力テンプレートを英語化し、`conventions.md` の「master ファイルは英語で記述する」規約に準拠させた

Closes #39

## Test plan
- [ ] 各スキルファイルに日本語が残っていないことを確認（`grep '[一-龯ぁ-んァ-ン]'`）
- [ ] 各スキルの動作仕様（ステップ数・フロー・ロジック）が変更前と同一であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)