### PR TITLE
enhance: ドキュメント整合性チェック用リポジトリ専用スキルを追加

### DIFF
--- a/.claude/skills/local/docs-validate/SKILL.md
+++ b/.claude/skills/local/docs-validate/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: docs-validate
+description: Validate documentation consistency across the repository - check skills, rules, symlinks, README structure, and translations
+---
+
+# Documentation Validation Skill
+
+Validate documentation consistency across the shared-claude-code repository. Scan skills, rules, symlinks, README structure sections, and Japanese translations to detect inconsistencies. Offer automatic fixes where possible.
+
+## Steps
+
+### Step 1: Scan Skills
+
+1. List all directories under `skills/` (excluding `README.md`)
+2. For each skill directory, verify:
+   - **1-1 SKILL.md exists with frontmatter**: `skills/<name>/SKILL.md` exists and contains `name` and `description` in YAML frontmatter
+   - **1-2 Symlink exists**: `.claude/skills/<name>` exists as a symlink pointing to `../../skills/<name>`
+     - Check with `readlink .claude/skills/<name>`
+     - If the symlink does not exist or points to a different target → flag as issue
+   - **1-3 README table entry**: `skills/README.md` contains a row with the skill name in the skills table
+     - Check with `grep` for the skill name in `skills/README.md`
+   - **1-4 Japanese translation**: `docs/ja-JP/skills/<name>/SKILL.md` exists
+3. Record each issue found with its category and details
+
+### Step 2: Scan Rules
+
+1. List all `.md` files under `rules/` (excluding `README.md` if present)
+2. For each rule file, verify:
+   - **2-1 Japanese translation**: `docs/ja-JP/rules/<filename>` exists
+3. Record each issue found
+
+### Step 3: Validate Structure Sections
+
+1. **README.md skills list**:
+   - Parse the Structure section in `README.md` and extract listed skill names
+   - Compare with actual directories under `skills/`
+   - Flag skills that exist on disk but are missing from the Structure section
+   - Flag entries in the Structure section that do not exist on disk
+2. **Japanese README.md skills list**:
+   - Parse the Structure section in `docs/ja-JP/README.md`
+   - Compare with the English `README.md` Structure section
+   - Flag any differences between the two lists
+
+### Step 4: Check Core Translations
+
+Verify that the following core translation files exist:
+
+| # | File | Check |
+|---|---|---|
+| 4-1 | `docs/ja-JP/README.md` | File exists |
+| 4-2 | `docs/ja-JP/CLAUDE.md` | File exists |
+| 4-3 | `docs/ja-JP/skills/README.md` | File exists |
+
+### Step 5: Present Findings
+
+1. If no issues were found in any category → display:
+   ```
+   All documentation consistency checks passed.
+   ```
+2. If issues were found → display results by category:
+   ```
+   ## Documentation Consistency Check Results
+
+   ### Skills Integrity
+   - `config-github-sync` — symlink missing
+   - `git-pr-create` — Japanese translation missing
+
+   ### Rules Integrity
+   - All passed
+
+   ### Structure Sections
+   - README.md — `config-github-sync` not listed in Structure section
+
+   ### Core Translations
+   - All passed
+
+   Auto-fixable items are available. Apply fixes? (all / select / skip)
+   ```
+3. Wait for user response before proceeding
+
+### Step 6: Apply Fixes
+
+Based on the user's response, apply fixes:
+
+**Auto-fixable** (apply with user approval):
+- **Missing symlink**: Create with `ln -s ../../skills/<name> .claude/skills/<name>`, then verify with `readlink`
+- **Missing skills/README.md entry**: Read `name` and `description` from `skills/<name>/SKILL.md` frontmatter, generate a table row in the format `| \`<name>\` | \`/<name>\` | <description> |`, and append it to the table in `skills/README.md`
+
+**Manual fix required** (display warning only):
+- **Structure section mismatch**: Display which files need updating and which skills are missing/extra
+- **Missing Japanese translation**: Display which files need to be created
+
+Display results after applying fixes:
+
+```
+## Fixes Applied
+
+- Created symlink: .claude/skills/config-github-sync
+- Added README table entry: config-github-sync
+
+Manual action required:
+- Update Structure section in README.md to include `config-github-sync`
+- Create Japanese translation: docs/ja-JP/skills/config-github-sync/SKILL.md
+```

--- a/docs/ja-JP/local-skills/docs-validate/SKILL.md
+++ b/docs/ja-JP/local-skills/docs-validate/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: docs-validate
+description: Validate documentation consistency across the repository - check skills, rules, symlinks, README structure, and translations
+---
+
+# ドキュメント整合性チェックスキル
+
+shared-claude-code リポジトリのドキュメント整合性を検証する。スキル、ルール、シンボリックリンク、README の Structure セクション、日本語翻訳をスキャンし、不整合を検出する。可能な場合は自動修正を提案する。
+
+## 処理手順
+
+### Step 1: スキルのスキャン
+
+1. `skills/` 配下のすべてのディレクトリを列挙する（`README.md` を除く）
+2. 各スキルディレクトリに対して以下を検証する:
+   - **1-1 SKILL.md の存在とフロントマター**: `skills/<name>/SKILL.md` が存在し、YAML フロントマターに `name` と `description` が含まれている
+   - **1-2 symlink の存在**: `.claude/skills/<name>` がシンボリックリンクとして存在し、`../../skills/<name>` を指している
+     - `readlink .claude/skills/<name>` で確認する
+     - シンボリックリンクが存在しないか、異なるターゲットを指している場合 → 問題としてフラグを立てる
+   - **1-3 README テーブルのエントリ**: `skills/README.md` のスキルテーブルにスキル名の行が含まれている
+     - `grep` でスキル名を `skills/README.md` 内で検索する
+   - **1-4 日本語翻訳**: `docs/ja-JP/skills/<name>/SKILL.md` が存在する
+3. 検出された各問題をカテゴリと詳細と共に記録する
+
+### Step 2: ルールのスキャン
+
+1. `rules/` 配下のすべての `.md` ファイルを列挙する（`README.md` がある場合は除く）
+2. 各ルールファイルに対して以下を検証する:
+   - **2-1 日本語翻訳**: `docs/ja-JP/rules/<filename>` が存在する
+3. 検出された各問題を記録する
+
+### Step 3: Structure セクションの検証
+
+1. **README.md のスキル一覧**:
+   - `README.md` の Structure セクションをパースし、記載されているスキル名を抽出する
+   - `skills/` 配下の実際のディレクトリと比較する
+   - ディスク上に存在するが Structure セクションに記載されていないスキルをフラグする
+   - Structure セクションに記載されているがディスク上に存在しないエントリをフラグする
+2. **日本語版 README.md のスキル一覧**:
+   - `docs/ja-JP/README.md` の Structure セクションをパースする
+   - 英語版 `README.md` の Structure セクションと比較する
+   - 2つのリスト間の差異をフラグする
+
+### Step 4: 主要翻訳ファイルの確認
+
+以下の主要翻訳ファイルが存在することを確認する:
+
+| # | ファイル | チェック内容 |
+|---|---|---|
+| 4-1 | `docs/ja-JP/README.md` | ファイルが存在する |
+| 4-2 | `docs/ja-JP/CLAUDE.md` | ファイルが存在する |
+| 4-3 | `docs/ja-JP/skills/README.md` | ファイルが存在する |
+
+### Step 5: 結果の提示
+
+1. すべてのカテゴリで問題が見つからなかった場合 → 以下を表示する:
+   ```
+   すべてのドキュメント整合性チェックに合格しました。
+   ```
+2. 問題が見つかった場合 → カテゴリ別に結果を表示する:
+   ```
+   ## ドキュメント整合性チェック結果
+
+   ### Skills 整合性
+   - `config-github-sync` — symlink 欠落
+   - `git-pr-create` — 日本語翻訳なし
+
+   ### Rules 整合性
+   - すべて合格 ✓
+
+   ### Structure セクション
+   - README.md — `config-github-sync` が Structure に未記載
+
+   ### 翻訳ファイル
+   - すべて合格 ✓
+
+   自動修正可能な項目があります。修正しますか？（全て / 選択 / スキップ）
+   ```
+3. 次のステップに進む前にユーザーの応答を待つ
+
+### Step 6: 修正の適用
+
+ユーザーの応答に基づいて修正を実施する:
+
+**自動修正可能**（ユーザーの承認後に適用）:
+- **symlink 欠落**: `ln -s ../../skills/<name> .claude/skills/<name>` で作成し、`readlink` で検証する
+- **skills/README.md のエントリ欠落**: `skills/<name>/SKILL.md` のフロントマターから `name` と `description` を読み取り、`| \`<name>\` | \`/<name>\` | <description> |` 形式のテーブル行を生成して `skills/README.md` のテーブルに追記する
+
+**手動修正が必要**（警告のみ表示）:
+- **Structure セクションの不整合**: 更新が必要なファイルと、欠落/余分なスキルを表示する
+- **日本語翻訳の欠落**: 作成が必要なファイルを表示する
+
+修正適用後に結果を表示する:
+
+```
+## 修正完了
+
+- symlink 作成: .claude/skills/config-github-sync
+- README テーブル行追加: config-github-sync
+
+手動対応が必要:
+- README.md の Structure セクションに `config-github-sync` を追加してください
+- 日本語翻訳を作成してください: docs/ja-JP/skills/config-github-sync/SKILL.md
+```


### PR DESCRIPTION
## Summary
- `.claude/skills/local/docs-validate/SKILL.md` にリポジトリ専用のドキュメント整合性チェックスキルを作成
- `docs/ja-JP/local-skills/docs-validate/SKILL.md` に日本語翻訳を作成
- 共有スキル（symlink）とリポジトリ専用スキルを `local/` サブディレクトリで分離する新規約を導入

Closes #53

## Test plan
- [ ] `/docs-validate` を実行し、既知の不整合（`.claude/skills/config-github-sync` symlink 欠落）が検出されることを確認
- [ ] 全チェック合格状態で合格メッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)