### PR TITLE
fix: config-github-syncの欠落シンボリックリンクを追加する

### DIFF
--- a/.claude/skills/config-github-sync
+++ b/.claude/skills/config-github-sync
@@ -1,0 +1,1 @@
+../../skills/config-github-sync


### PR DESCRIPTION
## Summary
- `.claude/skills/config-github-sync` へのシンボリックリンクが欠落していたため追加
- 他の6つの共有スキルにはすべてシンボリックリンクが存在しており、整合性を修正

Closes #58

## Test plan
- [ ] `readlink .claude/skills/config-github-sync` が `../../skills/config-github-sync` を返すことを確認
- [ ] `/local-docs-validate` で整合性チェックがすべてパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)