### PR TITLE
chore: リポジトリに .gitignore を追加し settings.local.json と .DS_Store を除外する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- リポジトリルートに `.gitignore` を新規作成
- `.claude/settings.local.json` をグローバル設定からリポジトリ管理に移管
- `.DS_Store` を追加（macOS 自動生成ファイルの除外）

Closes #60

## Test plan
- [ ] `.claude/settings.local.json` が `git status` に表示されないことを確認
- [ ] `.DS_Store` が `git status` に表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)