### PR TITLE
docs: CLAUDE.md のディレクトリ構成と手順記載を改善する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,14 +22,17 @@ ln -s ../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
 rules/          # Master rule files (English) — symlinked into .claude/rules/ of consuming repos
 skills/         # Master skill definitions — symlinked into .claude/skills/ of consuming repos
   README.md     # Skills index table — must be updated when adding a skill
+.claude/
+  rules/        # Symlinks → ../../rules/
+  skills/       # Symlinks → ../../skills/
 ci-templates/   # CI/config templates by language — copied to consuming repos via /config-github-sync
   nextjs/       # Next.js template (ESLint, Jest, TypeScript configs)
 .github/
   ISSUE_TEMPLATE/   # Issue templates (Japanese) — copied to consuming repos via /config-github-sync
 docs/ja-JP/     # Japanese translations (supplementary, not authoritative)
-.claude/
-  rules/        # Symlinks → ../../rules/
-  skills/       # Symlinks → ../../skills/
+  rules/        # Translations of rules/
+  skills/       # Translations of skills/
+  local-skills/ # Translations of local skills
 ```
 
 ## Adding a New Skill
@@ -49,3 +52,11 @@ Prefix the skill name with `local-` (e.g., `local-docs-validate`).
 
 1. Create `.claude/skills/local-<name>/SKILL.md` directly with YAML frontmatter (`name`, `description`)
 2. Add Japanese translation at `docs/ja-JP/local-skills/local-<name>/SKILL.md`
+
+## Adding a New Rule
+
+### Shared Rule (distributed to consuming repos via symlinks)
+
+1. Create `rules/<name>.md`
+2. Add a symlink: `.claude/rules/<name>.md -> ../../rules/<name>.md`
+3. Add Japanese translation at `docs/ja-JP/rules/<name>.md`

--- a/docs/ja-JP/CLAUDE.md
+++ b/docs/ja-JP/CLAUDE.md
@@ -22,14 +22,17 @@ ln -s ../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
 rules/          # マスタールールファイル（英語） — 消費リポジトリの .claude/rules/ にシンボリックリンク
 skills/         # マスタースキル定義 — 消費リポジトリの .claude/skills/ にシンボリックリンク
   README.md     # スキル一覧テーブル — スキル追加時に更新必須
+.claude/
+  rules/        # シンボリックリンク → ../../rules/
+  skills/       # シンボリックリンク → ../../skills/
 ci-templates/   # 言語別CIテンプレート — /config-github-sync によるファイルコピーで消費リポジトリに配布
   nextjs/       # Next.js テンプレート（ESLint, Jest, TypeScript設定）
 .github/
   ISSUE_TEMPLATE/   # Issueテンプレート（日本語） — /config-github-sync によるファイルコピーで消費リポジトリに配布
 docs/ja-JP/     # 日本語翻訳（補足資料。英語版が正）
-.claude/
-  rules/        # シンボリックリンク → ../../rules/
-  skills/       # シンボリックリンク → ../../skills/
+  rules/        # rules/ の翻訳
+  skills/       # skills/ の翻訳
+  local-skills/ # ローカルスキルの翻訳
 ```
 
 ## 新しいスキルの追加手順
@@ -49,3 +52,11 @@ docs/ja-JP/     # 日本語翻訳（補足資料。英語版が正）
 
 1. `.claude/skills/local-<name>/SKILL.md` を YAML フロントマター（`name`, `description`）付きで直接作成（シンボリックリンク不要）
 2. `docs/ja-JP/local-skills/local-<name>/SKILL.md` に日本語翻訳を追加
+
+## 新しいルールの追加手順
+
+### 共有ルール（シンボリックリンク経由で消費リポジトリに配布）
+
+1. `rules/<name>.md` を作成
+2. シンボリックリンクを追加: `.claude/rules/<name>.md -> ../../rules/<name>.md`
+3. `docs/ja-JP/rules/<name>.md` に日本語翻訳を追加


### PR DESCRIPTION
## Summary

- `Repository Structure` のディレクトリ順を「Claude が使うもの → 配布用 → 補足」の重要度順に変更（`rules/` → `skills/` → `.claude/` → `ci-templates/` → `.github/` → `docs/ja-JP/`）
- `docs/ja-JP/` の内部構造（`rules/`, `skills/`, `local-skills/`）をツリーに追加
- 「Adding a New Rule」セクションをスキルと同フォーマットで追加
- `docs/ja-JP/CLAUDE.md` を同内容で更新

Closes #62

## Test plan

- [ ] `CLAUDE.md` の Repository Structure ツリーが重要度順になっていることを確認
- [ ] `Adding a New Rule` セクションが存在することを確認
- [ ] `docs/ja-JP/CLAUDE.md` が英語版と対応した内容になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)