### PR TITLE
chore: PreCompactフックのファイル保存を削除しstdout出力のみに変更

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "REPO=$(git rev-parse --show-toplevel 2>/dev/null || pwd); BRANCH=$(git branch --show-current 2>/dev/null); STATUS=$(git status --short 2>/dev/null | head -20); TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S'); mkdir -p \"$REPO/.claude\"; { echo \"# Pre-Compact Summary\"; echo \"\"; echo \"Timestamp: $TIMESTAMP\"; echo \"\"; echo \"## Git State\"; echo \"\"; echo \"Branch: $BRANCH\"; if [ -n \"$STATUS\" ]; then echo \"\"; echo \"Uncommitted changes:\"; echo \"$STATUS\"; else echo \"Working tree: clean\"; fi; } | tee \"$REPO/.claude/compact-summary.md\""
+            "command": "REPO=$(git rev-parse --show-toplevel 2>/dev/null || pwd); BRANCH=$(git branch --show-current 2>/dev/null); STATUS=$(git status --short 2>/dev/null | head -20); TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S'); { echo \"# Pre-Compact Summary\"; echo \"\"; echo \"Timestamp: $TIMESTAMP\"; echo \"\"; echo \"## Git State\"; echo \"\"; echo \"Branch: $BRANCH\"; if [ -n \"$STATUS\" ]; then echo \"\"; echo \"Uncommitted changes:\"; echo \"$STATUS\"; else echo \"Working tree: clean\"; fi; }"
           }
         ]
       }

--- a/hooks/shared-hooks.json
+++ b/hooks/shared-hooks.json
@@ -87,7 +87,7 @@
           "_description": "Save git context to .claude/compact-summary.md before compaction",
           "_detect_by": "PreCompact|compact-summary",
           "type": "command",
-          "command": "REPO=$(git rev-parse --show-toplevel 2>/dev/null || pwd); BRANCH=$(git branch --show-current 2>/dev/null); STATUS=$(git status --short 2>/dev/null | head -20); TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S'); mkdir -p \"$REPO/.claude\"; { echo \"# Pre-Compact Summary\"; echo \"\"; echo \"Timestamp: $TIMESTAMP\"; echo \"\"; echo \"## Git State\"; echo \"\"; echo \"Branch: $BRANCH\"; if [ -n \"$STATUS\" ]; then echo \"\"; echo \"Uncommitted changes:\"; echo \"$STATUS\"; else echo \"Working tree: clean\"; fi; } | tee \"$REPO/.claude/compact-summary.md\""
+          "command": "REPO=$(git rev-parse --show-toplevel 2>/dev/null || pwd); BRANCH=$(git branch --show-current 2>/dev/null); STATUS=$(git status --short 2>/dev/null | head -20); TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S'); { echo \"# Pre-Compact Summary\"; echo \"\"; echo \"Timestamp: $TIMESTAMP\"; echo \"\"; echo \"## Git State\"; echo \"\"; echo \"Branch: $BRANCH\"; if [ -n \"$STATUS\" ]; then echo \"\"; echo \"Uncommitted changes:\"; echo \"$STATUS\"; else echo \"Working tree: clean\"; fi; }"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- `hooks/shared-hooks.json` と `.claude/settings.json` の PreCompact フックから `mkdir -p` と `tee` によるファイル保存を削除
- stdout 出力のみに変更し、`.claude/compact-summary.md` が生成されなくなる

Closes #92

## Test plan
- [ ] `/compact` 実行後に `.claude/compact-summary.md` が生成されないことを確認
- [ ] PreCompact フックの stdout 出力がコンパクトプロンプトに含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)