### PR TITLE
docs: READMEのシンボリックリンク手順を修正（パス誤りとmkdir追加）

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,20 +40,23 @@ docs/ja-JP/             # Japanese translations (supplementary, not authoritativ
 From the consuming repository root, create symlinks to shared rules and skills:
 
 ```bash
+# Create destination directories
+mkdir -p .claude/rules/shared .claude/skills
+
 # Rules
-ln -s ../../shared-claude-code/rules/conventions.md .claude/rules/shared/conventions.md
-ln -s ../../shared-claude-code/rules/security.md .claude/rules/shared/security.md
-ln -s ../../shared-claude-code/rules/tech-debt-checklist.md .claude/rules/shared/tech-debt-checklist.md
+ln -s ../../../../shared-claude-code/rules/conventions.md .claude/rules/shared/conventions.md
+ln -s ../../../../shared-claude-code/rules/security.md .claude/rules/shared/security.md
+ln -s ../../../../shared-claude-code/rules/tech-debt-checklist.md .claude/rules/shared/tech-debt-checklist.md
 
 # Skills
-ln -s ../../shared-claude-code/skills/config-claude-sync .claude/skills/config-claude-sync
-ln -s ../../shared-claude-code/skills/config-github-sync .claude/skills/config-github-sync
-ln -s ../../shared-claude-code/skills/git-branch-cleanup .claude/skills/git-branch-cleanup
-ln -s ../../shared-claude-code/skills/git-issue-create .claude/skills/git-issue-create
-ln -s ../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
-ln -s ../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
-ln -s ../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond
-ln -s ../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/tech-debt-audit-nextjs
+ln -s ../../../shared-claude-code/skills/config-claude-sync .claude/skills/config-claude-sync
+ln -s ../../../shared-claude-code/skills/config-github-sync .claude/skills/config-github-sync
+ln -s ../../../shared-claude-code/skills/git-branch-cleanup .claude/skills/git-branch-cleanup
+ln -s ../../../shared-claude-code/skills/git-issue-create .claude/skills/git-issue-create
+ln -s ../../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
+ln -s ../../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
+ln -s ../../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond
+ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/tech-debt-audit-nextjs
 ```
 
 Or use the `/config-claude-sync` skill to detect missing symlinks and create them automatically.

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -40,20 +40,23 @@ docs/ja-JP/             # 日本語翻訳（補足資料。英語版が正）
 消費リポジトリのルートから、共有ルールとスキルへのシンボリックリンクを作成する:
 
 ```bash
+# 配置先ディレクトリを作成
+mkdir -p .claude/rules/shared .claude/skills
+
 # ルール
-ln -s ../../shared-claude-code/rules/conventions.md .claude/rules/shared/conventions.md
-ln -s ../../shared-claude-code/rules/security.md .claude/rules/shared/security.md
-ln -s ../../shared-claude-code/rules/tech-debt-checklist.md .claude/rules/shared/tech-debt-checklist.md
+ln -s ../../../../shared-claude-code/rules/conventions.md .claude/rules/shared/conventions.md
+ln -s ../../../../shared-claude-code/rules/security.md .claude/rules/shared/security.md
+ln -s ../../../../shared-claude-code/rules/tech-debt-checklist.md .claude/rules/shared/tech-debt-checklist.md
 
 # スキル
-ln -s ../../shared-claude-code/skills/config-claude-sync .claude/skills/config-claude-sync
-ln -s ../../shared-claude-code/skills/config-github-sync .claude/skills/config-github-sync
-ln -s ../../shared-claude-code/skills/git-branch-cleanup .claude/skills/git-branch-cleanup
-ln -s ../../shared-claude-code/skills/git-issue-create .claude/skills/git-issue-create
-ln -s ../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
-ln -s ../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
-ln -s ../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond
-ln -s ../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/tech-debt-audit-nextjs
+ln -s ../../../shared-claude-code/skills/config-claude-sync .claude/skills/config-claude-sync
+ln -s ../../../shared-claude-code/skills/config-github-sync .claude/skills/config-github-sync
+ln -s ../../../shared-claude-code/skills/git-branch-cleanup .claude/skills/git-branch-cleanup
+ln -s ../../../shared-claude-code/skills/git-issue-create .claude/skills/git-issue-create
+ln -s ../../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
+ln -s ../../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
+ln -s ../../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond
+ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/tech-debt-audit-nextjs
 ```
 
 または `/config-claude-sync` スキルを使って、不足しているシンボリックリンクを自動検出・作成できる。


### PR DESCRIPTION
## Summary
- 消費リポジトリ側で `ln -s` 手順がそのまま動くよう、相対パスを正しい階層に修正（Rules: `../../../../`、Skills: `../../../`）
- 手順実行前に必要な `mkdir -p .claude/rules/shared .claude/skills` をコードブロック冒頭に追加
- `docs/ja-JP/README.md` にも同じ修正を反映

Closes #98

## Test plan
- [ ] 別の消費リポジトリで README のコードブロックをそのまま実行し、`mkdir` と `ln -s` がエラーなく完了することを確認
- [ ] `ls -l .claude/rules/shared/conventions.md` で symlink 先が壊れリンクでないことを確認
- [ ] `README.md` と `docs/ja-JP/README.md` の bash ブロックでコマンド部分が一致していることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)