### PR TITLE
docs: READMEに共通hooks同期の仕組みを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ skills/                 # Master skill definitions — symlinked into consuming 
 ├── git-pr-create/      # Create GitHub PR with analysis
 ├── git-review-respond/ # Respond to PR review comments
 └── tech-debt-audit-nextjs/ # Audit technical debt in Next.js projects
+hooks/                  # Shared hook definitions — merged into consuming repos' settings.json via config-claude-sync
+└── shared-hooks.json   # Shared hooks for PreToolUse / Stop / UserPromptSubmit / etc.
 ci-templates/           # CI/config templates by language — copied to consuming repos
 └── nextjs/             # Next.js template (ESLint, Jest, TypeScript configs)
 .github/
@@ -61,6 +63,8 @@ ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/t
 
 Or use the `/config-claude-sync` skill to detect missing symlinks and create them automatically.
 
+The `/config-claude-sync` skill also merges shared hook entries from `hooks/shared-hooks.json` into the consuming repository's `.claude/settings.json` (existing entries are preserved; only new or updated hooks are applied). No manual symlinking is required for hooks.
+
 ### 2. Copy GitHub configuration and CI templates
 
 Use the `/config-github-sync` skill to copy Issue templates, workflow files, and CI configuration templates to your repository.
@@ -69,7 +73,7 @@ Use the `/config-github-sync` skill to copy Issue templates, workflow files, and
 
 | Skill | Command | Description |
 |---|---|---|
-| `config-claude-sync` | `/config-claude-sync` | Detect missing symlinks and sync rules/skills under `.claude/` |
+| `config-claude-sync` | `/config-claude-sync` | Detect missing symlinks and sync rules/skills under `.claude/`, and merge shared hooks into `settings.json` |
 | `config-github-sync` | `/config-github-sync` | Detect diffs and copy-sync ISSUE_TEMPLATE/workflows under `.github/` |
 | `git-branch-cleanup` | `/git-branch-cleanup` | Local branch cleanup (switch to main, delete branches, pull) |
 | `git-issue-create` | `/git-issue-create` | Create Issue from conversation context (title, body, label inference, preview) |

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -21,6 +21,8 @@ skills/                 # マスタースキル定義 — シンボリックリ�
 ├── git-pr-create/      # 分析付きGitHub PR作成
 ├── git-review-respond/ # PRレビューコメントへの対応
 └── tech-debt-audit-nextjs/ # Next.jsプロジェクトの技術的負債調査
+hooks/                  # 共通hooks定義 — config-claude-sync で消費リポジトリの settings.json にマージ
+└── shared-hooks.json   # PreToolUse / Stop / UserPromptSubmit 等の共通hooks
 ci-templates/           # 言語別CI/設定テンプレート — ファイルコピーで消費リポジトリに配布
 └── nextjs/             # Next.js テンプレート（ESLint, Jest, TypeScript設定）
 .github/
@@ -61,6 +63,8 @@ ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/t
 
 または `/config-claude-sync` スキルを使って、不足しているシンボリックリンクを自動検出・作成できる。
 
+`/config-claude-sync` スキルは、`hooks/shared-hooks.json` の共通hooksエントリを消費リポジトリの `.claude/settings.json` にマージする処理も併せて行う（既存エントリは保持され、新規・更新のあったhookのみが適用される）。hooksにシンボリックリンクは不要。
+
 ### 2. GitHub設定とCIテンプレートのコピー
 
 `/config-github-sync` スキルを使って、Issueテンプレート、ワークフローファイル、CI設定テンプレートをリポジトリにコピーする。
@@ -69,7 +73,7 @@ ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/t
 
 | スキル | コマンド | 説明 |
 |---|---|---|
-| `config-claude-sync` | `/config-claude-sync` | `.claude/`配下（rules, skills）の差分検出・シンボリックリンク同期 |
+| `config-claude-sync` | `/config-claude-sync` | `.claude/`配下（rules, skills）の差分検出・シンボリックリンク同期、および共通hooksの `settings.json` へのマージ |
 | `config-github-sync` | `/config-github-sync` | `.github/`配下（ISSUE_TEMPLATE, workflows）の差分検出・コピー同期 |
 | `git-branch-cleanup` | `/git-branch-cleanup` | ローカルブランチクリーンアップ（main切替・ブランチ削除・pull） |
 | `git-issue-create` | `/git-issue-create` | 会話の文脈からIssue作成（タイトル・本文・ラベル推定・プレビュー） |


### PR DESCRIPTION
## Summary
- `README.md` と `docs/ja-JP/README.md` の `Structure` セクションに `hooks/`（`shared-hooks.json`）を追加
- `Getting Started` に、`/config-claude-sync` が `hooks/shared-hooks.json` を `.claude/settings.json` にマージする旨を追記
- `Available Skills` 表の `config-claude-sync` 説明に hooks マージを反映

Closes #100

## Test plan
- [ ] `README.md` / `docs/ja-JP/README.md` の `Structure` に `hooks/` が含まれていること
- [ ] `Getting Started` セクションで hooks 同期手順が `/config-claude-sync` から実行される旨が読み取れること
- [ ] `Available Skills` 表の `config-claude-sync` 行に hooks への言及があること
- [ ] 英語版と日本語版の記述内容に齟齬がないこと
- [ ] `CLAUDE.md` / `docs/ja-JP/CLAUDE.md` の hooks 関連記述と用語が整合していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)