### PR TITLE
fix: markdownlint workflow に glob 引数を追加し ignore を補強

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npx markdownlint-cli2
+      - run: npx markdownlint-cli2 "**/*.md"

--- a/ci-templates/markdownlint/.github/workflows/markdownlint.yml
+++ b/ci-templates/markdownlint/.github/workflows/markdownlint.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npx markdownlint-cli2
+      - run: npx markdownlint-cli2 "**/*.md"

--- a/ci-templates/markdownlint/.markdownlintignore
+++ b/ci-templates/markdownlint/.markdownlintignore
@@ -1,1 +1,3 @@
 ci-templates/
+.claude/
+node_modules/


### PR DESCRIPTION
## Summary
- `npx markdownlint-cli2` を引数なしで呼んでいたため exit 2 で必ず失敗していた問題を修正。本リポと `ci-templates/markdownlint/` 双方の workflow で `"**/*.md"` を明示的に渡すように変更
- `ci-templates/markdownlint/.markdownlintignore` に `.claude/` と `node_modules/` を追加し、shared を symlink で参照する下流リポで壊れたリンクや依存ファイルをスキャンして失敗しないようにする

Closes #102

## Test plan
- [x] ローカルで `npx markdownlint-cli2 "**/*.md"` を実行し exit 0 (43 files, 0 errors) を確認
- [ ] 本リポの `Markdown Lint` workflow がこの PR でグリーンになる
- [ ] 下流リポ (weight-training-record PR #3) で `/config-github-sync` 再同期後、CI がグリーンになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)