### PR TITLE
enhance: tech-debt-audit-flutter スキルを shared-claude-code に移植

### DIFF
--- a/.claude/skills/tech-debt-audit-flutter
+++ b/.claude/skills/tech-debt-audit-flutter
@@ -1,0 +1,1 @@
+../../skills/tech-debt-audit-flutter

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ skills/                 # Master skill definitions — symlinked into consuming 
 ├── git-issue-start/    # Start workflow from GitHub Issue
 ├── git-pr-create/      # Create GitHub PR with analysis
 ├── git-review-respond/ # Respond to PR review comments
+├── tech-debt-audit-flutter/ # Audit technical debt in Flutter / Dart projects
 └── tech-debt-audit-nextjs/ # Audit technical debt in Next.js projects
 hooks/                  # Shared hook definitions — merged into consuming repos' settings.json via config-claude-sync
 └── shared-hooks.json   # Shared hooks for PreToolUse / Stop / UserPromptSubmit / etc.
@@ -58,6 +59,7 @@ ln -s ../../../shared-claude-code/skills/git-issue-create .claude/skills/git-iss
 ln -s ../../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
 ln -s ../../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
 ln -s ../../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond
+ln -s ../../../shared-claude-code/skills/tech-debt-audit-flutter .claude/skills/tech-debt-audit-flutter
 ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/tech-debt-audit-nextjs
 ```
 
@@ -80,4 +82,5 @@ Use the `/config-github-sync` skill to copy Issue templates, workflow files, and
 | `git-issue-start` | `/git-issue-start <Issue#>` | Fetch Issue, validate labels, create branch, enter Plan Mode |
 | `git-pr-create` | `/git-pr-create` | Identify Issue, check size limits, analyze diff, create PR |
 | `git-review-respond` | `/git-review-respond <PR#>` | Analyze review comments, fix code, reply |
+| `tech-debt-audit-flutter` | `/tech-debt-audit-flutter` | Audit technical debt in Flutter / Dart projects with prioritized report |
 | `tech-debt-audit-nextjs` | `/tech-debt-audit-nextjs` | Audit technical debt in Next.js (App Router) projects with prioritized report |

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -20,6 +20,7 @@ skills/                 # マスタースキル定義 — シンボリックリ�
 ├── git-issue-start/    # GitHub Issueからの作業開始ワークフロー
 ├── git-pr-create/      # 分析付きGitHub PR作成
 ├── git-review-respond/ # PRレビューコメントへの対応
+├── tech-debt-audit-flutter/ # Flutter / Dartプロジェクトの技術的負債調査
 └── tech-debt-audit-nextjs/ # Next.jsプロジェクトの技術的負債調査
 hooks/                  # 共通hooks定義 — config-claude-sync で消費リポジトリの settings.json にマージ
 └── shared-hooks.json   # PreToolUse / Stop / UserPromptSubmit 等の共通hooks
@@ -58,6 +59,7 @@ ln -s ../../../shared-claude-code/skills/git-issue-create .claude/skills/git-iss
 ln -s ../../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
 ln -s ../../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
 ln -s ../../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond
+ln -s ../../../shared-claude-code/skills/tech-debt-audit-flutter .claude/skills/tech-debt-audit-flutter
 ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/tech-debt-audit-nextjs
 ```
 
@@ -80,4 +82,5 @@ ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/t
 | `git-issue-start` | `/git-issue-start <Issue#>` | Issue取得・ラベル検証・ブランチ作成・Plan Mode移行 |
 | `git-pr-create` | `/git-pr-create` | Issue特定・規模チェック・差分分析・PR作成 |
 | `git-review-respond` | `/git-review-respond <PR#>` | レビューコメント分析・コード修正・返信 |
+| `tech-debt-audit-flutter` | `/tech-debt-audit-flutter` | Flutter / Dartプロジェクトの技術的負債調査・優先度付きレポート生成 |
 | `tech-debt-audit-nextjs` | `/tech-debt-audit-nextjs` | Next.js（App Router）プロジェクトの技術的負債調査・優先度付きレポート生成 |

--- a/docs/ja-JP/skills/README.md
+++ b/docs/ja-JP/skills/README.md
@@ -11,3 +11,4 @@
 | `git-issue-start` | `/git-issue-start <Issue#>` | Issue取得・ラベル検証・ブランチ作成・Plan Mode移行 |
 | `git-pr-create` | `/git-pr-create` | Issue特定・規模チェック・差分分析・PR作成 |
 | `git-review-respond` | `/git-review-respond <PR#>` | レビューコメント分析・コード修正・返信 |
+| `tech-debt-audit-flutter` | `/tech-debt-audit-flutter` | Flutter / Dart プロジェクトの技術的負債を調査し、優先度付きレポートを生成する |

--- a/docs/ja-JP/skills/tech-debt-audit-flutter/SKILL.md
+++ b/docs/ja-JP/skills/tech-debt-audit-flutter/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: tech-debt-audit-flutter
+description: Flutter / Dart プロジェクトの技術的負債を調査し、優先度付きレポートを生成する
+---
+
+# Flutter 技術的負債調査スキル
+
+Flutter / Dart プロジェクトの技術的負債を調査する。`rules/tech-debt-checklist.md` の各カテゴリを Flutter / Dart 固有の手順で調査し、フレームワーク固有のチェック（Widget 肥大化、ステート管理の一貫性、生成コードの鮮度等）も実施する。ファイルパス・行番号・改善案を含む優先度付きレポートを出力する。
+
+## Steps
+
+### Step 1: プロジェクト検出
+
+1. リポジトリルートに `pubspec.yaml` が存在することを確認し、`flutter:` ブロックまたは `dependencies:` 配下の `flutter` SDK 制約を含むことで Flutter / Dart プロジェクトであることを検証する
+   - `pubspec.yaml` が存在しない場合 → 「エラー: Dart プロジェクトではありません（pubspec.yaml が見つかりません）。」と表示して終了
+   - `pubspec.yaml` は存在するが `flutter` 依存がない場合 → 「警告: 純粋な Dart パッケージのようです。Flutter 固有のチェック（Step 3 の Widget / State / Navigation）はスキップします。」と表示して続行
+2. アプリケーションプロジェクトの場合は `lib/main.dart` の存在を確認する。`main.dart` を持たないライブラリパッケージも有効な調査対象とする
+3. 後続コマンドで参照する Flutter CLI プレフィックスを決定する:
+   - `.fvmrc` または `.fvm/` が存在する → `fvm flutter ...` / `fvm dart ...` を使用
+   - それ以外 → `flutter ...` / `dart ...` を使用
+4. プロジェクト構造をスキャンしてレイアウトを把握する:
+   - `lib/` 配下のトップレベルディレクトリ（例: `app/`、`core/`、`features/`）を一覧化
+   - 各 feature ディレクトリについて、クリーンアーキテクチャレイヤリング（`presentation/` / `application/` / `domain/` / `data/`）を採用しているか、その他の構造かを記録
+   - `test/`、`integration_test/`、`analysis_options.yaml`、`.github/workflows/` の有無と内容を確認
+
+### Step 2: 共通チェックリスト調査
+
+`rules/tech-debt-checklist.md` の各カテゴリを Flutter / Dart コンテキストで調査する:
+
+#### コードの重複
+
+- 画面間で繰り返される Widget ツリーパターン（類似の `Scaffold` + `AppBar` + `ListView` の骨格、繰り返される `Padding` / `Container` のネスト等）の検索
+- feature 間で重複するデータ取得や Repository 実装の確認
+- `lib/core/` および `features/*/` 間で重複するユーティリティ関数の検索
+- 共有 value object の不在を示唆する `freezed` モデルフィールドの重複検出
+
+#### アーキテクチャとレイヤー分離
+
+- feature-first / クリーンアーキテクチャレイヤリングを採用している場合、レイヤー違反を確認:
+  - `presentation/` ファイルが `data/` を直接インポートしている（`application/` 経由とすべき）
+  - `domain/` ファイルが Flutter、Riverpod、Drift 等のフレームワークをインポートしている
+  - `application/` ファイルが `presentation/` のウィジェットをインポートしている
+- feature 間の直接インポート（`features/foo/` が `features/bar/` をインポート）の確認 — 共有コードは `core/` に配置すべき
+- 循環インポートチェーンの検出（疑わしい循環への手動 grep、または設定されていれば `dart run import_sorter` / `dart run dependency_validator`）
+- `application/`（Riverpod notifier）に属すべきステートフルロジックが `StatefulWidget` の setState ブロックに漏れていないか確認
+
+#### エラーハンドリング
+
+- 失敗しうる Future（I/O、ネットワーク、プラグイン呼び出し）への `await` 呼び出しが `try / catch` の外側に存在していないか検索
+- 空の `catch` ブロック（`catch (_) {}`）やスタックトレースを握り潰す広範すぎる `catch (e)` の確認
+- `Future` / `Stream` コンシューマで `onError` が欠如しているケース、および失敗を無視する `unawaited()` 呼び出しの確認
+- UI レイヤで `AsyncValue` コンシューマ（`ref.watch(...)`）の `error` 分岐欠如（`when` / `whenData` でエラーを落としている）の確認
+- 型付きエラークラスとすべき `throw Exception('...')` 文字列の検索
+
+#### 型安全性
+
+- `.dart` ファイル全体での `dynamic` パラメータ / 戻り値型、および値の袋として使われる `Object?` の検索
+- null 安全性を回避する null アサーション演算子（`!`）の使用フラグ付け
+- 実行時に失敗しうる `as` キャストの検索
+- 境界で `freezed` モデルへパースする代わりに複数レイヤを通過する `Map<String, dynamic>` の確認
+- 初期化子の型が非自明な `var` 宣言での型注釈欠如のフラグ付け
+
+#### デッドコード
+
+- `<flutter-prefix> analyze` を実行し、`unused_element`、`unused_import`、`unused_local_variable`、`dead_code` の診断を収集
+- コメントアウトされたコードブロック（コードに見える 3 行以上の連続コメント行）の検索
+- 一度も再インポートされていない `export` 文の確認
+- 現スプリントより古い TODO / FIXME / XXX コメント（放置作業の可能性）の特定
+
+#### 定数と設定
+
+- `build()` メソッド内のマジックナンバー（theme トークンや名前付き定数とすべき素のパディング / 半径 / 期間リテラル）の検索
+- ソースファイルに埋め込まれたハードコード URL、API ベースパス、フィーチャーフラグ文字列の確認
+- `Widget` コンストラクタで見落とされた `const` 機会（アナライザルール `prefer_const_constructors`）の確認
+- ファイル間で重複する `Duration` / `EdgeInsets` / 色リテラル定義の特定
+
+#### コンポーネント / モジュールの肥大化
+
+- **300 行**を超える `.dart` ファイルの特定（生成ファイル `*.g.dart` / `*.freezed.dart` を除く）
+- **100 行**を超える `build()` メソッドのフラグ付け — `extract widget` リファクタの候補
+- **4 段階以上**ネストした単一の Widget ツリーのフラグ付け
+- 無関係な責務を混在させた約 10 個以上の public メソッドを持つクラスのフラグ付け
+
+#### 依存関係の管理
+
+- `pubspec.yaml` の依存関係と `lib/` 内の実際の import を突き合わせて未使用パッケージを発見
+- `<flutter-prefix> pub outdated` を実行し、メジャーバージョンが複数遅れているパッケージのフラグ付け
+- 機能が重複するパッケージ（例: 2 つの HTTP クライアント、2 つの日付ライブラリ、2 つのモッキングフレームワーク）の検出
+- バージョン固定を回避する git-ref や path 依存（`git:` / `path:` エントリ）のフラグ付け
+- `test/`、`build_runner` 設定、CI のいずれからも参照されていない `dev_dependencies` エントリの確認
+
+#### テスト
+
+- `<flutter-prefix> test --coverage` を実行（または欠如を記録）し、`coverage/lcov.info` を確認して未カバーファイルを把握
+- `lib/features/*/` のファイル数と `test/features/*/` のファイル数を比較して feature ごとのカバレッジギャップを推定
+- ウィジェット / 統合テストが欠如しているクリティカルパス（認証、決済、永続化、同期）の特定
+- インメモリ実装ではなく Repository をモックするテスト（統合バグを隠す可能性）の確認
+- DI なしで実時刻の `DateTime.now()`、`Random()`、ファイルシステム状態に依存するテストのフラグ付け
+
+#### アクセシビリティ
+
+- `Semantics` ラベルなしで非インタラクティブコンテンツをラップする `GestureDetector` / `InkWell` の検索
+- `Image`、`Icon`、`CircleAvatar` での `semanticLabel` / `semanticsLabel` 欠如の確認
+- `tooltip` のない `IconButton` / `FloatingActionButton` の確認
+- 色だけによる伝達（アイコンやラベルを伴わない赤 / 緑のテキスト等）のフラグ付け
+- `TextField` での `labelText` / `hintText` セマンティクス欠如の確認
+
+#### パフォーマンス
+
+- `build()` 内の高コスト計算（ソート、JSON パース、正規表現コンパイル等）— `application/` でメモ化すべきものの確認
+- 大量の子要素をハードコードした `ListView(...)` のフラグ付け — 可能な場合は `itemExtent` を指定した `ListView.builder` を使用すべき
+- ホットパス（アニメーションティック、スクロールリスナー）での `setState` 呼び出しによる大規模サブツリーの再構築の検索
+- 生成されたが破棄されない `StreamSubscription`、`TextEditingController`、`AnimationController`、`FocusNode` の特定
+- ウィジェットツリー差分最適化を無効化するウィジェットコンストラクタの `const` 欠如の確認
+
+#### セキュリティ
+
+- 未検証のソースから取得する git / URL / path 依存の `pubspec.yaml` 内確認
+- ソースに埋め込まれたシークレット、API キー、トークン（`String _apiKey = '...'`）の検索
+- `flutter_secure_storage` / Keychain に置くべき機密データへの `SharedPreferences` 使用のフラグ付け
+- SQL、ファイルパス、プラットフォームチャネルに直接渡される未検証の外部入力の確認
+- ネットワーク呼び出しでハードコードされた `http://`（非 TLS）URL の確認
+
+### Step 3: Flutter / Dart 固有の調査
+
+共通チェックリストでカバーされない Flutter / Dart 規約固有のチェック。
+
+#### Widget / build メソッドの肥大化
+
+- 100 行を超える `build()` メソッドの一覧化
+- 中間 `extract widget` リファクタなしに 4 階層以上ネストした Widget ツリーの特定
+- 単一の `build()` 内でレイアウト・データ変換・イベントハンドリングを混在させている画面のフラグ付け
+
+#### ステート管理の一貫性
+
+- ステート管理アプローチの混在（同一プロジェクト内で `setState` + Riverpod + Provider + Bloc）の検出
+- プロジェクトが Riverpod を使用している場合、`@riverpod` 生成プロバイダとすべき手書きの `Provider(...)` / `StateProvider(...)` のフラグ付け
+- プロジェクトが Riverpod を使用している場合、notifier に置くべきビジネスステートを保持する `StatefulWidget` のフラグ付け
+- ステート管理レイヤを迂回するグローバル可変シングルトン（トップレベルの `final foo = Foo();`）の確認
+
+#### Async / Stream ハンドリング
+
+- Riverpod の `AsyncValue` が一貫性のあるプロジェクトでの `FutureBuilder` / `StreamBuilder` 使用の特定
+- `initState` で生成して `dispose` で `cancel()` していない未キャンセル `StreamSubscription` のフラグ付け
+- 未破棄の `TextEditingController` / `AnimationController` / `FocusNode` / `ScrollController` のフラグ付け
+- ウィジェット内の `Timer` および `Future.delayed` 使用での dispose 時キャンセル欠如の確認
+
+#### 生成コードの鮮度
+
+- `<flutter-prefix> dart run build_runner build --delete-conflicting-outputs` を実行し `git status` を確認
+- いずれかの `*.g.dart` または `*.freezed.dart` ファイルが変更された → コミット済みの生成コードが古く再生成が必要
+- 生成ファイルが（プロジェクトの規約に従って）リポジトリにコミットされており、ignore されていないことを検証
+
+#### ナビゲーション規約
+
+- プロジェクトが `go_router` を使用している場合、`context.push` / `context.go` / `context.pop` 経由とすべき直接的な `Navigator.push` / `Navigator.pop` / `Navigator.of(context)` 使用の検索
+- ルート定義が一元化（例: `lib/app/router.dart`）されており、画面に散在していないことの確認
+- ルートに宣言する代わりに画面内で手動パースされているディープリンクパラメータのフラグ付け
+
+#### レイヤー境界の調査（プロジェクト固有）
+
+- プロジェクトの `CLAUDE.md` または `.claude/rules/architecture.md` がレイヤリング規約を定義している場合、各 `lib/features/<feature>/` ディレクトリが規定の構造に従っているかを検証
+- 規約が完全なレイヤーセットを要求している箇所でレイヤーが欠如している feature（例: `application/` のない `presentation/` のみ）のフラグ付け
+- `core/` がガラクタ置き場として使われていないことの確認 — 単一 feature でしか使われないユーティリティはその feature 内に配置すべき
+
+#### Build / CI カバレッジギャップ
+
+- `.github/workflows/*.yml` を調査して PR で実行されるチェックを把握
+- 重要と判断される欠如した CI ステップのフラグ付け:
+  - `<flutter-prefix> format --output=none --set-exit-code .`（または `dart format`）
+  - `<flutter-prefix> test --coverage` とカバレッジレポーター
+  - 非ブロッキング助言としての `<flutter-prefix> pub outdated --exit-if-no-update-needed=false`
+  - 生成コード鮮度チェック（`build_runner build` + `git diff --exit-code`）
+- 最近リグレッションを引き起こした実績がない限り、これらは LOW 優先度とする
+
+### Step 4: レポート生成
+
+以下のフォーマットで調査結果を出力する:
+
+```text
+## Technical Debt Audit Report — Flutter
+
+Project: <pubspec.yaml のプロジェクト名>
+Scan date: <YYYY-MM-DD>
+Files scanned: <件数>
+
+### HIGH Priority (<件数> items)
+
+1. **[<カテゴリ>]** `path/to/file.dart:L<行番号>`
+   **Finding:** <問題の説明>
+   **Recommendation:** <修正方法>
+
+### MEDIUM Priority (<件数> items)
+...
+
+### LOW Priority (<件数> items)
+...
+
+### Summary
+
+| Category | HIGH | MEDIUM | LOW |
+|---|---|---|---|
+| Code Duplication | - | - | - |
+| Architecture & Layering | - | - | - |
+| Error Handling | - | - | - |
+| Type Safety | - | - | - |
+| Dead Code | - | - | - |
+| Constants & Configuration | - | - | - |
+| Component / Module Size | - | - | - |
+| Dependency Management | - | - | - |
+| Testing | - | - | - |
+| Accessibility | - | - | - |
+| Performance | - | - | - |
+| Security | - | - | - |
+| Widget / build Bloat | - | - | - |
+| State Management Consistency | - | - | - |
+| Async / Stream Handling | - | - | - |
+| Generated Code Freshness | - | - | - |
+| Navigation Conventions | - | - | - |
+| Layer Boundary | - | - | - |
+| Build / CI Coverage Gaps | - | - | - |
+| **Total** | **X** | **X** | **X** |
+```
+
+#### 優先度判定基準
+
+| 優先度 | 基準 |
+|---|---|
+| **HIGH** | セキュリティリスク、データ損失の可能性、本番障害、リーク原因となる未破棄リソース、クリティカルパスでの未処理エラー |
+| **MEDIUM** | 保守性・可読性の著しい低下、パフォーマンスへの影響、型安全性の欠如、ステート管理の不一致 |
+| **LOW** | ベストプラクティスからの逸脱、コード品質の改善提案、外観的な問題、助言レベルの CI ギャップ |
+
+### Step 5: Issue 作成
+
+レポート提示後、どの検出項目を GitHub Issue として作成するかユーザーに確認する:
+
+1. すべての検出項目を番号付きリストで表示し、以下のプロンプトを表示する:
+
+   ```text
+   Issue化する項目を番号で指定してください（例: 1,3,5 / all / none）
+   ```
+
+2. ユーザーの回答に基づいて対応する:
+   - **`none`**: スキルを終了
+   - **`all`**: すべての検出項目に対して Issue を作成
+   - **特定の番号**: 選択された検出項目のみ Issue を作成
+3. 選択された各検出項目について、`/git-issue-create` の規約に従い Issue を作成する:
+   - **タイトル**: 日本語、検出内容の簡潔な説明
+   - **ラベル**: `enhancement` + レポートの優先度に対応する優先度ラベル（`HIGH` → `priority: high`、`MEDIUM` → `priority: medium`、`LOW` → `priority: low`）
+   - **本文**: カテゴリ、ファイルパス、検出内容の詳細、改善案を含める
+4. 作成された Issue の番号と URL の一覧を表示する

--- a/skills/README.md
+++ b/skills/README.md
@@ -11,4 +11,5 @@ Shared skills distributed to consuming repositories via symlinks. Each skill is 
 | `git-issue-start` | `/git-issue-start <Issue#>` | Fetch Issue, validate labels, create branch, enter Plan Mode |
 | `git-pr-create` | `/git-pr-create` | Identify Issue, check size limits, analyze diff, create PR |
 | `git-review-respond` | `/git-review-respond <PR#>` | Analyze review comments, fix code, reply |
+| `tech-debt-audit-flutter` | `/tech-debt-audit-flutter` | Audit technical debt in Flutter / Dart projects with prioritized report |
 | `tech-debt-audit-nextjs` | `/tech-debt-audit-nextjs` | Audit technical debt in Next.js (App Router) projects with prioritized report |

--- a/skills/tech-debt-audit-flutter/SKILL.md
+++ b/skills/tech-debt-audit-flutter/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: tech-debt-audit-flutter
+description: Audit technical debt in Flutter / Dart projects - analyze code against checklist and generate prioritized report
+---
+
+# Flutter Technical Debt Audit Skill
+
+Audit a Flutter / Dart project for technical debt. Investigates each category from `rules/tech-debt-checklist.md` using Flutter / Dart-specific procedures, plus framework-specific checks (Widget bloat, state management consistency, generated code freshness, etc.). Outputs a prioritized report with file paths, line numbers, and remediation suggestions.
+
+## Steps
+
+### Step 1: Project Detection
+
+1. Verify the project is a Flutter / Dart project by checking for `pubspec.yaml` at the repository root and confirming it contains a `flutter:` block or a `flutter` SDK constraint under `dependencies:`
+   - If `pubspec.yaml` is absent → display "Error: This does not appear to be a Dart project (no pubspec.yaml found)." and exit
+   - If `pubspec.yaml` exists but has no `flutter` dependency → display "Warning: This appears to be a pure Dart package. Flutter-specific checks (Step 3 Widget / State / Navigation) will be skipped." and continue
+2. Confirm the application entry point exists at `lib/main.dart` (for application projects). Library packages without `main.dart` are still valid audit targets
+3. Determine the Flutter CLI prefix to reference in subsequent commands:
+   - If `.fvmrc` or `.fvm/` exists → use `fvm flutter ...` / `fvm dart ...`
+   - Otherwise → use `flutter ...` / `dart ...`
+4. Scan the project structure to understand the layout:
+   - List top-level directories under `lib/` (e.g., `app/`, `core/`, `features/`)
+   - For each feature directory, note whether a clean-architecture layering (`presentation/` / `application/` / `domain/` / `data/`) is used, or some other structure
+   - Note the presence and shape of `test/`, `integration_test/`, `analysis_options.yaml`, `.github/workflows/`
+
+### Step 2: Common Checklist Audit
+
+Investigate each category from `rules/tech-debt-checklist.md` in the Flutter / Dart context:
+
+#### Code Duplication
+
+- Search for repeated Widget tree patterns across screens (e.g., similar `Scaffold` + `AppBar` + `ListView` skeletons, repeated `Padding` / `Container` nesting)
+- Check for duplicated data-fetching or Repository implementations across features
+- Look for repeated utility functions across `lib/core/` and `features/*/`
+- Flag duplicated `freezed` model fields that suggest a missing shared value object
+
+#### Architecture & Layering
+
+- If the project uses feature-first / clean-architecture layering, check for cross-layer violations:
+  - `presentation/` files importing from `data/` directly (should go through `application/`)
+  - `domain/` files importing Flutter, Riverpod, Drift, or any framework
+  - `application/` files importing widgets from `presentation/`
+- Look for direct cross-feature imports (`features/foo/` importing `features/bar/`) — shared code belongs in `core/`
+- Detect circular import chains (manual grep on suspected cycles, or `dart run import_sorter` / `dart run dependency_validator` if configured)
+- Check whether stateful logic that belongs in `application/` (Riverpod notifiers) is leaking into `StatefulWidget` setState blocks
+
+#### Error Handling
+
+- Search for `await` calls outside any `try / catch` where the awaited future can fail (I/O, network, plugin calls)
+- Look for empty `catch` blocks (`catch (_) {}`) and overly broad `catch (e)` that swallow stack traces
+- Check `Future` / `Stream` consumers for missing `onError` and for `unawaited()` calls that ignore failures
+- In the UI layer, check `AsyncValue` consumers (`ref.watch(...)`) for missing `error` branches (`when` / `whenData` that drops errors)
+- Search for `throw Exception('...')` strings that should be typed error classes
+
+#### Type Safety
+
+- Search `.dart` files for `dynamic` parameter / return types and `Object?` used as a bag of values
+- Flag null-assertion operator (`!`) usage that bypasses null safety
+- Search for `as` casts that could fail at runtime
+- Look for `Map<String, dynamic>` passed through multiple layers instead of being parsed into a `freezed` model at the boundary
+- Flag missing type annotations on `var` declarations whose initializer type is non-obvious
+
+#### Dead Code
+
+- Run `<flutter-prefix> analyze` and collect `unused_element`, `unused_import`, `unused_local_variable`, `dead_code` diagnostics
+- Search for commented-out code blocks (3+ consecutive comment lines that look like code)
+- Check for `export` statements that are never re-imported
+- Identify TODO / FIXME / XXX comments older than the current sprint that may indicate abandoned work
+
+#### Constants & Configuration
+
+- Search for magic numbers in `build()` methods (raw padding / radius / duration literals that should be theme tokens or named constants)
+- Look for hard-coded URLs, API base paths, or feature-flag strings embedded in source files
+- Check for `const` opportunities missed on `Widget` constructors (analyzer rule `prefer_const_constructors`)
+- Identify duplicated `Duration` / `EdgeInsets` / color literal definitions across files
+
+#### Component / Module Size
+
+- Identify `.dart` files exceeding **300 lines** (excluding generated `*.g.dart` / `*.freezed.dart`)
+- Flag `build()` methods exceeding **100 lines** — candidates for `extract widget` refactor
+- Flag any single Widget tree exceeding **4 levels of nesting**
+- Flag classes with more than ~10 public methods that mix unrelated concerns
+
+#### Dependency Management
+
+- Cross-reference `pubspec.yaml` dependencies against actual imports in `lib/` to find unused packages
+- Run `<flutter-prefix> pub outdated` and flag packages multiple major versions behind
+- Look for duplicate packages providing overlapping functionality (e.g., two HTTP clients, two date libraries, two mocking frameworks)
+- Flag git-ref or path dependencies (`git:` / `path:` entries) that bypass version pinning
+- Check for `dev_dependencies` entries that are not actually referenced in `test/`, `build_runner` configs, or CI
+
+#### Testing
+
+- Run `<flutter-prefix> test --coverage` (or note its absence) and inspect `coverage/lcov.info` for uncovered files
+- Compare the file count under `lib/features/*/` against `test/features/*/` to estimate coverage gaps per feature
+- Identify critical paths (auth, payment, persistence, sync) lacking widget or integration tests
+- Look for tests that mock the Repository instead of using an in-memory implementation, which may hide integration bugs
+- Flag tests that depend on real `DateTime.now()`, `Random()`, or file-system state without injection
+
+#### Accessibility
+
+- Search for `GestureDetector` / `InkWell` wrapping non-interactive content without a `Semantics` label
+- Check `Image`, `Icon`, and `CircleAvatar` for missing `semanticLabel` / `semanticsLabel`
+- Look for `IconButton` / `FloatingActionButton` without `tooltip`
+- Flag color-only signals (red / green text without an accompanying icon or label)
+- Check `TextField` for missing `labelText` / `hintText` semantics
+
+#### Performance
+
+- Look for expensive computations inside `build()` (sorting, JSON parsing, regex compilation) that should be memoized in `application/`
+- Flag `ListView(...)` with a large hard-coded children list — should be `ListView.builder` with `itemExtent` when feasible
+- Search for `setState` calls in hot paths (animation tick, scroll listeners) that rebuild large subtrees
+- Identify `StreamSubscription`, `TextEditingController`, `AnimationController`, `FocusNode` that are created but never disposed
+- Look for missing `const` on widget constructors that disables widget-tree diffing optimization
+
+#### Security
+
+- Check `pubspec.yaml` for git / URL / path dependencies that pull from unvetted sources
+- Search for secrets, API keys, or tokens embedded in source (`String _apiKey = '...'`)
+- Flag use of `SharedPreferences` for sensitive data that should live in `flutter_secure_storage` / Keychain
+- Look for unvalidated external input passed directly into SQL, file paths, or platform channels
+- Check for `http://` (non-TLS) URLs hard-coded in network calls
+
+### Step 3: Flutter / Dart-Specific Audit
+
+Checks specific to Flutter / Dart conventions that are not covered by the common checklist.
+
+#### Widget / build Method Bloat
+
+- List `build()` methods exceeding 100 lines
+- Identify Widget trees nested 4+ levels deep without intermediate `extract widget` refactors
+- Flag screens that mix layout, data transformation, and event handling in a single `build()`
+
+#### State Management Consistency
+
+- Detect mixing of state-management approaches (`setState` + Riverpod + Provider + Bloc in the same project)
+- If the project uses Riverpod, flag hand-written `Provider(...)` / `StateProvider(...)` that should be `@riverpod` generated providers
+- If the project uses Riverpod, flag `StatefulWidget` instances holding business state that should live in a notifier
+- Look for global mutable singletons (`final foo = Foo();` at top-level) that bypass the state-management layer
+
+#### Async / Stream Handling
+
+- Identify `FutureBuilder` / `StreamBuilder` usage in projects where Riverpod `AsyncValue` would be more consistent
+- Flag uncancelled `StreamSubscription` (created in `initState` without `cancel()` in `dispose`)
+- Flag undisposed `TextEditingController` / `AnimationController` / `FocusNode` / `ScrollController`
+- Check `Timer` and `Future.delayed` usage in widgets for missing cancellation on dispose
+
+#### Generated Code Freshness
+
+- Run `<flutter-prefix> dart run build_runner build --delete-conflicting-outputs` and check `git status`
+- If any `*.g.dart` or `*.freezed.dart` files changed → the committed generated code is stale and must be regenerated
+- Verify that generated files are committed to the repo (per project convention) and not ignored
+
+#### Navigation Conventions
+
+- If the project uses `go_router`, search for direct `Navigator.push` / `Navigator.pop` / `Navigator.of(context)` usage that should go through `context.push` / `context.go` / `context.pop`
+- Check that route definitions are centralized (e.g., `lib/app/router.dart`) and not scattered across screens
+- Flag deep-link parameters parsed manually inside screens instead of declared on the route
+
+#### Layer Boundary Audit (project-specific)
+
+- If the project's `CLAUDE.md` or `.claude/rules/architecture.md` defines layering rules, verify each `lib/features/<feature>/` directory matches the prescribed structure
+- Flag features missing a layer (e.g., `presentation/` only with no `application/`) where the convention requires the full set
+- Check that `core/` is not used as a junk-drawer — utilities used by a single feature should live in that feature
+
+#### Build / CI Coverage Gaps
+
+- Inspect `.github/workflows/*.yml` for which checks run on PRs
+- Flag missing CI steps that the audit considers important:
+  - `<flutter-prefix> format --output=none --set-exit-code .` (or `dart format`)
+  - `<flutter-prefix> test --coverage` with a coverage reporter
+  - `<flutter-prefix> pub outdated --exit-if-no-update-needed=false` as a non-blocking advisory
+  - Generated-code freshness check (`build_runner build` + `git diff --exit-code`)
+- Note these as LOW priority unless the project has had recent regressions from the missing check
+
+### Step 4: Generate Report
+
+Output the audit results in the following format:
+
+```text
+## Technical Debt Audit Report — Flutter
+
+Project: <project name from pubspec.yaml>
+Scan date: <YYYY-MM-DD>
+Files scanned: <count>
+
+### HIGH Priority (<count> items)
+
+1. **[<Category>]** `path/to/file.dart:L<line>`
+   **Finding:** <description of the issue>
+   **Recommendation:** <how to fix>
+
+### MEDIUM Priority (<count> items)
+...
+
+### LOW Priority (<count> items)
+...
+
+### Summary
+
+| Category | HIGH | MEDIUM | LOW |
+|---|---|---|---|
+| Code Duplication | - | - | - |
+| Architecture & Layering | - | - | - |
+| Error Handling | - | - | - |
+| Type Safety | - | - | - |
+| Dead Code | - | - | - |
+| Constants & Configuration | - | - | - |
+| Component / Module Size | - | - | - |
+| Dependency Management | - | - | - |
+| Testing | - | - | - |
+| Accessibility | - | - | - |
+| Performance | - | - | - |
+| Security | - | - | - |
+| Widget / build Bloat | - | - | - |
+| State Management Consistency | - | - | - |
+| Async / Stream Handling | - | - | - |
+| Generated Code Freshness | - | - | - |
+| Navigation Conventions | - | - | - |
+| Layer Boundary | - | - | - |
+| Build / CI Coverage Gaps | - | - | - |
+| **Total** | **X** | **X** | **X** |
+```
+
+#### Priority Criteria
+
+| Priority | Criteria |
+|---|---|
+| **HIGH** | Security risks, potential data loss, production failures, undisposed resources causing leaks, unhandled errors on critical paths |
+| **MEDIUM** | Significant maintainability or readability degradation, performance impact, missing type safety, state-management inconsistency |
+| **LOW** | Best-practice deviations, code quality improvements, cosmetic issues, advisory CI gaps |
+
+### Step 5: Issue Creation
+
+After presenting the report, ask the user which findings they want to create as GitHub Issues:
+
+1. Display a numbered list of all findings and prompt:
+
+   ```text
+   Issue化する項目を番号で指定してください（例: 1,3,5 / all / none）
+   ```
+
+2. Based on the user's response:
+   - **`none`**: End the skill
+   - **`all`**: Create an Issue for every finding
+   - **Specific numbers**: Create Issues for selected findings only
+3. For each selected finding, create an Issue using `/git-issue-create` conventions:
+   - **Title**: Japanese, concise description of the finding
+   - **Labels**: `enhancement` + priority label mapped from the report (`HIGH` → `priority: high`, `MEDIUM` → `priority: medium`, `LOW` → `priority: low`)
+   - **Body**: Include the category, file path, finding details, and recommendation
+4. Display the list of created Issues with their numbers and URLs


### PR DESCRIPTION
## Summary

- `tech-debt-audit-flutter` スキルを weight-training-record から shared-claude-code に移植（英語マスター + 日本語版）
- `.claude/skills/tech-debt-audit-flutter` symlink を追加し `/config-claude-sync` で他リポジトリにも配布可能に
- `skills/README.md`, `docs/ja-JP/skills/README.md`, ルート `README.md`, `docs/ja-JP/README.md` のスキル一覧・構成図・symlink セットアップ手順に flutter エントリを追加

移植元 (weight-training-record) は project-neutral に書かれており、文言調整は不要だったためそのまま転記。`fvm` 検出と `architecture.md` 参照はいずれも条件分岐で実装されているため、消費リポジトリ側の構成に依らず動作する。

## PR サイズ

- 変更ファイル: 7
- 追加行数: 511 行

300 行制限を超過しているが、502 行は新規 SKILL.md（英 251 + 日 251）であり、`conventions.md` の例外条項「新規ディレクトリ・ファイル作成が主体」に該当する。

## Out of Scope（フォローアップ）

- weight-training-record 側 `.claude/skills/tech-debt-audit-flutter/SKILL.md` を本リポジトリへの symlink に置き換える作業は別 Issue として起票予定（Acceptance Criteria 第 5 項）

## Test plan

- [ ] `/tech-debt-audit-flutter` が Claude Code から呼び出せる（本リポジトリで symlink 経由 → スキル一覧に登場することを確認済み）
- [ ] `skills/README.md`・`docs/ja-JP/skills/README.md` のテーブルに flutter 行が追加されている
- [ ] ルート `README.md`・`docs/ja-JP/README.md` の構成図・symlink セットアップ手順・スキル一覧の 3 箇所すべてに flutter が反映されている
- [ ] `.claude/skills/tech-debt-audit-flutter` が `../../skills/tech-debt-audit-flutter` を指す symlink になっている

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)