### PR TITLE
enhance: git-issue-create スキルにマイルストーン設定機能を追加

### DIFF
--- a/docs/ja-JP/skills/git-issue-create/SKILL.md
+++ b/docs/ja-JP/skills/git-issue-create/SKILL.md
@@ -71,7 +71,18 @@ description: Create a GitHub Issue from conversation context - analyze context, 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
 
-### Step 3: プレビュー・ユーザー確認
+### Step 3: オープン中マイルストーンの取得
+
+現在のリポジトリでオープン中のマイルストーン一覧を取得する:
+
+```bash
+gh api "repos/{owner}/{repo}/milestones?state=open" --jq '.[].title'
+```
+
+- コマンドが失敗した場合、または空の結果が返った場合 → マイルストーン処理は行わず、未設定のまま次のステップへ進む。プレビューおよび結果表示からもマイルストーン行を省略する。
+- それ以外の場合は、取得したタイトル一覧をプレビューで利用するために保持する。既定値は「設定しない」。
+
+### Step 4: プレビュー・ユーザー確認
 
 以下の形式でプレビューを表示し、ユーザーの承認を得る:
 
@@ -81,6 +92,8 @@ description: Create a GitHub Issue from conversation context - analyze context, 
 **タイトル**: <タイトル>
 **種類ラベル**: <ラベル>
 **優先度ラベル**: <ラベル>
+**マイルストーン**: <選択されたタイトル または "設定しない">
+  (候補: <タイトル1>, <タイトル2>, ...)
 
 ---
 <本文>
@@ -89,15 +102,21 @@ description: Create a GitHub Issue from conversation context - analyze context, 
 この内容でIssueを作成してよろしいですか？修正点があればお知らせください。
 ```
 
-- ユーザーが承認した場合 → Step 4へ進む
-- ユーザーが修正を指示した場合 → 修正を反映して再度プレビューを表示する
+- 「**マイルストーン**:」行と「(候補: ...)」行は、Step 3 で 1 件以上のマイルストーンが取得できた場合のみ表示する。取得済みの全タイトルを列挙する。
+- ユーザーが承認した場合 → Step 5へ進む
+- ユーザーが修正を指示した場合（マイルストーンの選択変更も含む） → 修正を反映して再度プレビューを表示する
 
-### Step 4: Issue作成
+### Step 5: Issue作成
 
-1. `gh issue create` でIssueを作成する:
+1. `gh issue create` でIssueを作成する。`--milestone "<タイトル>"` は、Step 4 でユーザーが具体的なマイルストーンを選択した場合のみ付与する（「設定しない」やマイルストーンが存在しない場合は省略する）:
 
    ```bash
-   gh issue create --title "<タイトル>" --label "<種類ラベル>" --label "<優先度ラベル>" --body "$(cat <<'EOF'
+   gh issue create \
+     --title "<タイトル>" \
+     --label "<種類ラベル>" \
+     --label "<優先度ラベル>" \
+     [--milestone "<タイトル>"] \
+     --body "$(cat <<'EOF'
    <本文>
    EOF
    )"
@@ -105,9 +124,9 @@ description: Create a GitHub Issue from conversation context - analyze context, 
 
 2. 失敗した場合はエラーメッセージを表示して終了する
 
-### Step 5: 結果表示
+### Step 6: 結果表示
 
-作成結果を以下の形式で表示する:
+作成結果を以下の形式で表示する。`マイルストーン` 行はマイルストーンが設定された場合のみ表示する:
 
 ```text
 ## Issue作成完了
@@ -117,4 +136,5 @@ Issue #XX: <タイトル>
 
 - 種類ラベル: <種類ラベル>
 - 優先度ラベル: <優先度ラベル>
+- マイルストーン: <タイトル>
 ```

--- a/skills/git-issue-create/SKILL.md
+++ b/skills/git-issue-create/SKILL.md
@@ -71,7 +71,18 @@ Automate the workflow for creating GitHub Issues from conversation context. Perf
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
 
-### Step 3: Preview and User Confirmation
+### Step 3: Fetch Open Milestones
+
+Fetch the list of open milestones for the current repository:
+
+```bash
+gh api "repos/{owner}/{repo}/milestones?state=open" --jq '.[].title'
+```
+
+- If the command fails or returns an empty list → no milestone handling; proceed to the next step with the milestone unset and omit the milestone line from the preview and the result display.
+- Otherwise, keep the list of titles for use in the preview. Default selection is `none` (no milestone).
+
+### Step 4: Preview and User Confirmation
 
 Display a preview in the following format and obtain user approval:
 
@@ -81,6 +92,8 @@ Display a preview in the following format and obtain user approval:
 **Title**: <title>
 **Type Label**: <label>
 **Priority Label**: <label>
+**Milestone**: <selected title or "none">
+  (available: <title1>, <title2>, ...)
 
 ---
 <body>
@@ -89,15 +102,21 @@ Display a preview in the following format and obtain user approval:
 Shall I create the Issue with this content? Let me know if you'd like any changes.
 ```
 
-- If the user approves → proceed to Step 4
-- If the user requests changes → apply the changes and display the preview again
+- The `**Milestone**:` line and the `(available: ...)` line are shown only when Step 3 returned at least one milestone. List all available titles.
+- If the user approves → proceed to Step 5
+- If the user requests changes (including switching the milestone selection) → apply the changes and display the preview again
 
-### Step 4: Create Issue
+### Step 5: Create Issue
 
-1. Create the Issue using `gh issue create`:
+1. Create the Issue using `gh issue create`. Include `--milestone "<title>"` only when the user selected a specific milestone in Step 4; omit it when the selection is `none` or when no milestones were available:
 
    ```bash
-   gh issue create --title "<title>" --label "<type label>" --label "<priority label>" --body "$(cat <<'EOF'
+   gh issue create \
+     --title "<title>" \
+     --label "<type label>" \
+     --label "<priority label>" \
+     [--milestone "<title>"] \
+     --body "$(cat <<'EOF'
    <body>
    EOF
    )"
@@ -105,9 +124,9 @@ Shall I create the Issue with this content? Let me know if you'd like any change
 
 2. If it fails, display the error message and exit
 
-### Step 5: Display Results
+### Step 6: Display Results
 
-Display the creation results in the following format:
+Display the creation results in the following format. The `Milestone` line is shown only when a milestone was assigned:
 
 ```text
 ## Issue Created
@@ -117,4 +136,5 @@ Issue #XX: <title>
 
 - Type Label: <type label>
 - Priority Label: <priority label>
+- Milestone: <title>
 ```


### PR DESCRIPTION
## Summary
- `git-issue-create` スキルにマイルストーン設定機能を追加
- オープン中マイルストーンが存在する場合、Step 3 でタイトル一覧を取得し、プレビューに「マイルストーン」行と候補一覧を表示
- ユーザーがプレビューで選択を指示した場合のみ `gh issue create --milestone "<title>"` を付与
- マイルストーンが 0 件のリポジトリでは従来通りのフロー（マイルストーン関連の表示・問いかけを行わない）
- 英語マスター (`skills/git-issue-create/SKILL.md`) と日本語翻訳 (`docs/ja-JP/skills/git-issue-create/SKILL.md`) の両方を更新

Closes #108

## Test plan
- [ ] マイルストーンを持つリポジトリで `/git-issue-create` を実行し、プレビューにマイルストーン行と候補一覧が表示されること
- [ ] プレビューから「マイルストーンを X にして」のように指示し、再プレビューで選択が反映されること
- [ ] 承認後、`gh issue create --milestone "<title>"` で Issue が作成され、GitHub 上でマイルストーンが紐付いていること
- [ ] マイルストーンが 0 件のリポジトリで実行し、プレビューにマイルストーン行が表示されず、`gh issue create` に `--milestone` が付かないこと
- [ ] 結果表示において、選択時のみ「Milestone:」行が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)