### PR TITLE
enhance: git-branch-cleanup を対象 worktree / branch 限定に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ skills/                 # Master skill definitions — symlinked into consuming 
 ├── README.md           # Skills index table
 ├── config-claude-sync/ # Sync shared rules/skills via symlinks
 ├── config-github-sync/ # Sync .github files and CI templates via file copy
-├── git-branch-cleanup/ # Local branch cleanup after PR merge
+├── git-branch-cleanup/ # Worktree-scoped cleanup after PR merge
 ├── git-issue-create/   # Create GitHub Issue from conversation context
 ├── git-issue-start/    # Start workflow from GitHub Issue
 ├── git-pr-create/      # Create GitHub PR with analysis
@@ -77,7 +77,7 @@ Use the `/config-github-sync` skill to copy Issue templates, workflow files, and
 |---|---|---|
 | `config-claude-sync` | `/config-claude-sync` | Detect missing symlinks and sync rules/skills under `.claude/`, and merge shared hooks into `settings.json` |
 | `config-github-sync` | `/config-github-sync` | Detect diffs and copy-sync ISSUE_TEMPLATE/workflows under `.github/` |
-| `git-branch-cleanup` | `/git-branch-cleanup` | Local branch cleanup (switch to main, delete branches, pull) |
+| `git-branch-cleanup` | `/git-branch-cleanup` | Worktree-scoped cleanup — remove current worktree and its working branch |
 | `git-issue-create` | `/git-issue-create` | Create Issue from conversation context (title, body, label inference, preview) |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Fetch Issue, validate labels, create branch, enter Plan Mode |
 | `git-pr-create` | `/git-pr-create` | Identify Issue, check size limits, analyze diff, create PR |

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -15,7 +15,7 @@ skills/                 # マスタースキル定義 — シンボリックリ�
 ├── README.md           # スキル一覧テーブル
 ├── config-claude-sync/ # ルール・スキルをシンボリックリンクで同期
 ├── config-github-sync/ # .githubファイルとCIテンプレートをファイルコピーで同期
-├── git-branch-cleanup/ # PRマージ後のローカルブランチクリーンアップ
+├── git-branch-cleanup/ # PRマージ後の対象 worktree 限定クリーンアップ
 ├── git-issue-create/   # 会話コンテキストからGitHub Issueを作成
 ├── git-issue-start/    # GitHub Issueからの作業開始ワークフロー
 ├── git-pr-create/      # 分析付きGitHub PR作成
@@ -77,7 +77,7 @@ ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/t
 |---|---|---|
 | `config-claude-sync` | `/config-claude-sync` | `.claude/`配下（rules, skills）の差分検出・シンボリックリンク同期、および共通hooksの `settings.json` へのマージ |
 | `config-github-sync` | `/config-github-sync` | `.github/`配下（ISSUE_TEMPLATE, workflows）の差分検出・コピー同期 |
-| `git-branch-cleanup` | `/git-branch-cleanup` | ローカルブランチクリーンアップ（main切替・ブランチ削除・pull） |
+| `git-branch-cleanup` | `/git-branch-cleanup` | 対象 worktree とその作業ブランチに限定したクリーンアップ |
 | `git-issue-create` | `/git-issue-create` | 会話の文脈からIssue作成（タイトル・本文・ラベル推定・プレビュー） |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Issue取得・ラベル検証・ブランチ作成・Plan Mode移行 |
 | `git-pr-create` | `/git-pr-create` | Issue特定・規模チェック・差分分析・PR作成 |

--- a/docs/ja-JP/skills/README.md
+++ b/docs/ja-JP/skills/README.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | `config-claude-sync` | `/config-claude-sync` | `.claude/`配下（rules, skills）の差分検出・シンボリックリンク同期 |
 | `config-github-sync` | `/config-github-sync` | `.github/`配下（ISSUE_TEMPLATE, workflows）の差分検出・コピー同期 |
-| `git-branch-cleanup` | `/git-branch-cleanup` | ローカルブランチクリーンアップ（main切替・ブランチ削除・pull） |
+| `git-branch-cleanup` | `/git-branch-cleanup` | 対象 worktree とその作業ブランチに限定したクリーンアップ |
 | `git-issue-create` | `/git-issue-create` | 会話の文脈からIssue作成（タイトル・本文・ラベル推定・プレビュー） |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Issue取得・ラベル検証・ブランチ作成・Plan Mode移行 |
 | `git-pr-create` | `/git-pr-create` | Issue特定・規模チェック・差分分析・PR作成 |

--- a/docs/ja-JP/skills/git-branch-cleanup/SKILL.md
+++ b/docs/ja-JP/skills/git-branch-cleanup/SKILL.md
@@ -1,64 +1,96 @@
 ---
 name: git-branch-cleanup
-description: Clean up local branches - switch to main, delete all local branches, and pull latest
+description: Worktree-scoped cleanup — remove the current worktree and its working branch only, leaving other worktrees and branches untouched
 ---
 
 # Branch Cleanup Skill
 
-PR作成・マージ後のローカルブランチクリーンアップを自動化する。mainへの切り替え・ローカルブランチ削除・最新取得を一連の流れで行う。
+PR マージ後に **現在の worktree** と **そこで checkout している作業ブランチのみ** を片付けるスキル。
+
+このスキルは、Claude Code と Codex がそれぞれ独自の clone / worktree で並行して作業し、複数の Issue が同時進行している運用を前提とする。他のローカルブランチや他の worktree（Claude Code のメインクローン、別 Issue の Codex worktree など）は **絶対に削除せず**、それらが存在しても本スキルは停止しない。
+
+## 対象スコープ
+
+- **対象**: このスキルを実行した worktree と、そこで現在 checkout されている作業ブランチ。
+- **対象外**: 他のローカルブランチ、他の linked worktree、他の clone。検査も変更もしない。
+- 引数は受け取らない。
 
 ## 実行方針
 
 このスキルはユーザーが明示的に `/git-branch-cleanup` を実行した時点で全操作が承認済みである。以下を厳守すること:
 
-- **全操作を1つのBash tool callのコマンドチェーンで実行する。Bash tool callを分割してはならない**
-- `git checkout main`, `git branch -D`, `git pull` はすべて事前承認済みの操作として扱う
+- **全操作を 1 つの Bash tool call のコマンドチェーンで実行する。Bash tool call を分割してはならない**
+- `git checkout main`, `git worktree remove`, `git branch -D`, `git fetch origin` はすべて事前承認済みの操作として扱う
 - ステップ間で「実行してよいですか？」「続行しますか？」等の質問を挟まない
-- エラーが発生した場合のみ停止する
+- エラーが発生した場合、または「対象なし（主 worktree かつ main 上）」を検出した場合のみ停止する
 
 ## 実行コマンド
 
-以下のコマンドチェーンを**1つのBash tool call**でそのまま実行する:
+以下のコマンドチェーンを **1 つの Bash tool call** でそのまま実行する:
 
 ```bash
-set -e; STATUS=$(git status --porcelain); [ -n "$STATUS" ] && echo "エラー: 未コミットの変更があります。" && exit 1; git checkout main 2>&1; git branch | grep -v '^\*' | xargs -r git branch -D 2>&1; git pull 2>&1
+set -e
+STATUS=$(git status --porcelain)
+if [ -n "$STATUS" ]; then echo "エラー: 未コミットの変更があります。"; exit 1; fi
+BRANCH=$(git branch --show-current)
+GITDIR=$(git rev-parse --git-dir)
+COMMONDIR=$(git rev-parse --git-common-dir)
+if [ "$GITDIR" = "$COMMONDIR" ]; then
+  if [ "$BRANCH" = "main" ]; then echo "対象なし: 主 worktree の main にいるため削除対象がありません。"; exit 0; fi
+  git checkout main
+  git branch -D "$BRANCH"
+else
+  WORKTREE_PATH=$(git rev-parse --show-toplevel)
+  MAIN_PATH=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
+  cd "$MAIN_PATH"
+  git worktree remove "$WORKTREE_PATH"
+  git branch -D "$BRANCH"
+fi
+git fetch origin
 ```
 
 ## 処理手順（参考）
 
 ### Step 1: 前提条件の確認
 
-1. `git status --porcelain` で未コミット変更を確認する
+1. 現在の worktree で `git status --porcelain` を実行し、未コミット変更を確認する
    - 変更がある場合 → エラーを表示して終了する
-2. `git branch --show-current` で現在のブランチを取得する
-   - 既に `main` の場合 → ブランチ切り替え（Step 2）をスキップする
+2. `git branch --show-current` で作業ブランチ名を保持する
+3. `git rev-parse --git-dir` と `git rev-parse --git-common-dir` を比較して、現在の worktree が **主 worktree（メインクローン）** か **linked worktree** かを判定する（一致 → 主、不一致 → linked）
 
-### Step 2: mainブランチへ切り替え
+### Step 2A: 主 worktree の場合
 
-1. `git checkout main` を実行する
-2. 失敗した場合はエラーを表示して終了する
+主 worktree（メインクローン）で実行された場合:
 
-### Step 3: ローカルブランチの削除
+1. 現在ブランチが `main` → `対象なし: 主 worktree の main にいるため削除対象がありません。` を表示して終了する。他のブランチや worktree には一切触れない。
+2. それ以外 → `git checkout main` の後、`git branch -D <作業ブランチ>` を実行する。
 
-1. `git branch` でmain以外のローカルブランチ一覧を取得する
-   - ブランチがない場合 → 「削除対象のブランチはありません」と表示してStep 4へ進む
-2. 各ブランチを `git branch -D <ブランチ名>` で削除する
+### Step 2B: linked worktree の場合
 
-### Step 4: 最新取得
+linked worktree で実行された場合:
 
-1. `git pull` を実行する
-2. 失敗した場合はエラーを表示する
+1. `git rev-parse --show-toplevel` で対象 worktree のパスを取得する。
+2. `git worktree list --porcelain` の先頭 `worktree` 行から主 worktree のパスを取得する。
+3. `cd` で主 worktree へ移動する。
+4. `git worktree remove <linked worktree のパス>` で worktree ディレクトリを削除する。
+5. `git branch -D <作業ブランチ>` でブランチを削除する。
+6. 他の linked worktree やそのブランチは一切触らない。
 
-### Step 5: 結果表示
+### Step 3: リモート参照の更新
+
+1. `git fetch origin` で remote-tracking refs を更新する。
+2. 主 worktree の `main` の作業コピーは自動で fast-forward しない。ユーザーが次にその worktree へ戻ったタイミングで pull する想定。
+
+### Step 4: 結果表示
 
 完了結果を以下の形式で表示する:
 
 ```text
 ## ブランチクリーンアップ完了
 
-- 現在のブランチ: main
-- 削除したブランチ: X件
-  - <ブランチ名1>
-  - <ブランチ名2>
-- git pull: <結果サマリ>
+- 削除した worktree: <path もしくは "なし（主 worktree）">
+- 削除したブランチ: <ブランチ名>
+- git fetch origin: <結果サマリ>
 ```
+
+Step 2A で「対象なし」終了した場合は、その旨を表示し削除関連の行は省略する。

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,7 @@ Shared skills distributed to consuming repositories via symlinks. Each skill is 
 |---|---|---|
 | `config-claude-sync` | `/config-claude-sync` | Detect missing symlinks and sync rules/skills under `.claude/` |
 | `config-github-sync` | `/config-github-sync` | Detect diffs and copy-sync ISSUE_TEMPLATE/workflows under `.github/` |
-| `git-branch-cleanup` | `/git-branch-cleanup` | Local branch cleanup (switch to main, delete branches, pull) |
+| `git-branch-cleanup` | `/git-branch-cleanup` | Worktree-scoped cleanup — remove current worktree and its working branch |
 | `git-issue-create` | `/git-issue-create` | Create Issue from conversation context (title, body, label inference, preview) |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Fetch Issue, validate labels, create branch, enter Plan Mode |
 | `git-pr-create` | `/git-pr-create` | Identify Issue, check size limits, analyze diff, create PR |

--- a/skills/git-branch-cleanup/SKILL.md
+++ b/skills/git-branch-cleanup/SKILL.md
@@ -1,64 +1,96 @@
 ---
 name: git-branch-cleanup
-description: Clean up local branches - switch to main, delete all local branches, and pull latest
+description: Worktree-scoped cleanup — remove the current worktree and its working branch only, leaving other worktrees and branches untouched
 ---
 
 # Branch Cleanup Skill
 
-Automate local branch cleanup after PR creation/merge. Switch to main, delete local branches, and pull latest in a single flow.
+Clean up only the **current worktree** and the **working branch checked out in it** after a PR is merged.
+
+This skill assumes a parallel development workflow where Claude Code and Codex each operate in their own clones / worktrees and may have multiple in-flight Issues at once. Other local branches and other worktrees (e.g., Claude Code's main clone, another Issue's Codex worktree) are **never** deleted and never block this skill.
+
+## Scope
+
+- **Targets**: the current worktree (the one this skill is invoked from) and the branch currently checked out in it.
+- **Out of scope**: every other local branch, every other linked worktree, and every other clone. They are neither inspected nor modified.
+- The skill takes no arguments.
 
 ## Execution Policy
 
 All operations are pre-approved when the user explicitly runs `/git-branch-cleanup`. Strictly follow these rules:
 
 - **Execute all operations in a single Bash tool call command chain. Never split into multiple Bash tool calls**
-- Treat `git checkout main`, `git branch -D`, and `git pull` as pre-approved operations
+- Treat `git checkout main`, `git worktree remove`, `git branch -D`, and `git fetch origin` as pre-approved operations
 - Do not insert confirmation prompts like "Proceed?" or "Continue?" between steps
-- Stop only when an error occurs
+- Stop only when an error occurs, or when the skill detects "nothing to clean" (primary worktree on `main`)
 
 ## Execution Command
 
 Execute the following command chain as-is in **a single Bash tool call**:
 
 ```bash
-set -e; STATUS=$(git status --porcelain); [ -n "$STATUS" ] && echo "エラー: 未コミットの変更があります。" && exit 1; git checkout main 2>&1; git branch | grep -v '^\*' | xargs -r git branch -D 2>&1; git pull 2>&1
+set -e
+STATUS=$(git status --porcelain)
+if [ -n "$STATUS" ]; then echo "エラー: 未コミットの変更があります。"; exit 1; fi
+BRANCH=$(git branch --show-current)
+GITDIR=$(git rev-parse --git-dir)
+COMMONDIR=$(git rev-parse --git-common-dir)
+if [ "$GITDIR" = "$COMMONDIR" ]; then
+  if [ "$BRANCH" = "main" ]; then echo "対象なし: 主 worktree の main にいるため削除対象がありません。"; exit 0; fi
+  git checkout main
+  git branch -D "$BRANCH"
+else
+  WORKTREE_PATH=$(git rev-parse --show-toplevel)
+  MAIN_PATH=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
+  cd "$MAIN_PATH"
+  git worktree remove "$WORKTREE_PATH"
+  git branch -D "$BRANCH"
+fi
+git fetch origin
 ```
 
 ## Steps (Reference)
 
 ### Step 1: Check Prerequisites
 
-1. Check for uncommitted changes with `git status --porcelain`
+1. Check for uncommitted changes in the current worktree with `git status --porcelain`
    - If changes exist → display error and exit
-2. Get current branch with `git branch --show-current`
-   - If already on `main` → skip branch switch (Step 2)
+2. Record the working branch with `git branch --show-current`
+3. Detect whether the current worktree is the **primary worktree** (main clone) or a **linked worktree** by comparing `git rev-parse --git-dir` and `git rev-parse --git-common-dir` (equal → primary, differ → linked)
 
-### Step 2: Switch to main Branch
+### Step 2A: Primary Worktree
 
-1. Run `git checkout main`
-2. If it fails, display error and exit
+If the current worktree is the primary worktree (the main clone):
 
-### Step 3: Delete Local Branches
+1. If the current branch is `main` → display `対象なし: 主 worktree の main にいるため削除対象がありません。` and exit. Do not touch any other branch or worktree.
+2. Otherwise → `git checkout main`, then `git branch -D <working branch>`.
 
-1. Get list of local branches other than main with `git branch`
-   - If no branches exist → display "No branches to delete" and proceed to Step 4
-2. Delete each branch with `git branch -D <branch-name>`
+### Step 2B: Linked Worktree
 
-### Step 4: Pull Latest
+If the current worktree is a linked worktree:
 
-1. Run `git pull`
-2. If it fails, display error
+1. Capture the worktree path with `git rev-parse --show-toplevel`.
+2. Capture the primary worktree path from the first `worktree` line of `git worktree list --porcelain`.
+3. `cd` into the primary worktree.
+4. `git worktree remove <linked worktree path>` to remove the worktree directory.
+5. `git branch -D <working branch>` to delete the branch.
+6. Other linked worktrees and their branches are left alone.
 
-### Step 5: Display Results
+### Step 3: Refresh Remote Refs
+
+1. Run `git fetch origin` to update remote-tracking refs.
+2. The primary worktree's `main` working copy is **not** fast-forwarded automatically — the user updates it when they next switch to that worktree.
+
+### Step 4: Display Results
 
 Display results in the following format:
 
 ```text
 ## ブランチクリーンアップ完了
 
-- 現在のブランチ: main
-- 削除したブランチ: X件
-  - <ブランチ名1>
-  - <ブランチ名2>
-- git pull: <結果サマリ>
+- 削除した worktree: <path もしくは "なし（主 worktree）">
+- 削除したブランチ: <branch 名>
+- git fetch origin: <結果サマリ>
 ```
+
+If the skill exited at Step 2A as "対象なし", report that instead and skip the deletion lines.


### PR DESCRIPTION
## Summary
- 現在の worktree とそこの作業ブランチに対象を限定（主／linked worktree を検出）
- 主 worktree かつ main 上のときは「対象なし」で終了
- 全ブランチ削除と git pull を廃止し、git fetch origin に置換
- 並行開発で他の worktree / branch を巻き込まないことを skill 文書に明記
- 英語マスタ・日本語訳・root/skills README を同時更新

Closes #110

## Test plan
- [ ] 未コミット変更がある状態で実行し、エラー終了することを確認
- [ ] 主 worktree の main で実行し、「対象なし」表示で終了することを確認
- [ ] 主 worktree の feature ブランチで実行し、main 切替・対象ブランチ削除・他ブランチが残ることを確認
- [ ] linked worktree で実行し、対象 worktree 削除・ブランチ削除・他 worktree が無傷であることを確認
- [ ] いずれの分岐でも git fetch origin が実行され remote-tracking refs が更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)