### PR TITLE
fix: git-branch-cleanup の primary worktree でローカル main を fast-forward

### DIFF
--- a/docs/ja-JP/skills/git-branch-cleanup/SKILL.md
+++ b/docs/ja-JP/skills/git-branch-cleanup/SKILL.md
@@ -20,7 +20,7 @@ PR マージ後に **現在の worktree** と **そこで checkout している�
 このスキルはユーザーが明示的に `/git-branch-cleanup` を実行した時点で全操作が承認済みである。以下を厳守すること:
 
 - **全操作を 1 つの Bash tool call のコマンドチェーンで実行する。Bash tool call を分割してはならない**
-- `git checkout main`, `git worktree remove`, `git branch -D`, `git fetch origin` はすべて事前承認済みの操作として扱う
+- `git checkout main`, `git worktree remove`, `git branch -D`, `git fetch origin`, `git pull --ff-only origin main` はすべて事前承認済みの操作として扱う
 - ステップ間で「実行してよいですか？」「続行しますか？」等の質問を挟まない
 - エラーが発生した場合、または「対象なし（主 worktree かつ main 上）」を検出した場合のみ停止する
 
@@ -39,14 +39,15 @@ if [ "$GITDIR" = "$COMMONDIR" ]; then
   if [ "$BRANCH" = "main" ]; then echo "対象なし: 主 worktree の main にいるため削除対象がありません。"; exit 0; fi
   git checkout main
   git branch -D "$BRANCH"
+  git pull --ff-only origin main
 else
   WORKTREE_PATH=$(git rev-parse --show-toplevel)
   MAIN_PATH=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
   cd "$MAIN_PATH"
   git worktree remove "$WORKTREE_PATH"
   git branch -D "$BRANCH"
+  git fetch origin
 fi
-git fetch origin
 ```
 
 ## 処理手順（参考）
@@ -63,7 +64,7 @@ git fetch origin
 主 worktree（メインクローン）で実行された場合:
 
 1. 現在ブランチが `main` → `対象なし: 主 worktree の main にいるため削除対象がありません。` を表示して終了する。他のブランチや worktree には一切触れない。
-2. それ以外 → `git checkout main` の後、`git branch -D <作業ブランチ>` を実行する。
+2. それ以外 → `git checkout main` の後、`git branch -D <作業ブランチ>` を実行し、続けて `git pull --ff-only origin main` でローカル `main` を `origin/main` に fast-forward する。ローカル `main` に想定外のコミットがある場合は `--ff-only` により失敗して停止し、ユーザが気付ける。
 
 ### Step 2B: linked worktree の場合
 
@@ -78,8 +79,8 @@ linked worktree で実行された場合:
 
 ### Step 3: リモート参照の更新
 
-1. `git fetch origin` で remote-tracking refs を更新する。
-2. 主 worktree の `main` の作業コピーは自動で fast-forward しない。ユーザーが次にその worktree へ戻ったタイミングで pull する想定。
+- **主 worktree 分岐**: Step 2A の `git pull --ff-only origin main` ですでにローカル `main` を `origin/main` に fast-forward 済み。
+- **linked worktree 分岐**: `git fetch origin` で remote-tracking refs のみ更新する。主 worktree で checkout 中のブランチ（`main` とは限らない）には触れない。ユーザーが次にその worktree へ戻ったタイミングで pull する想定。
 
 ### Step 4: 結果表示
 

--- a/skills/git-branch-cleanup/SKILL.md
+++ b/skills/git-branch-cleanup/SKILL.md
@@ -20,7 +20,7 @@ This skill assumes a parallel development workflow where Claude Code and Codex e
 All operations are pre-approved when the user explicitly runs `/git-branch-cleanup`. Strictly follow these rules:
 
 - **Execute all operations in a single Bash tool call command chain. Never split into multiple Bash tool calls**
-- Treat `git checkout main`, `git worktree remove`, `git branch -D`, and `git fetch origin` as pre-approved operations
+- Treat `git checkout main`, `git worktree remove`, `git branch -D`, `git fetch origin`, and `git pull --ff-only origin main` as pre-approved operations
 - Do not insert confirmation prompts like "Proceed?" or "Continue?" between steps
 - Stop only when an error occurs, or when the skill detects "nothing to clean" (primary worktree on `main`)
 
@@ -39,14 +39,15 @@ if [ "$GITDIR" = "$COMMONDIR" ]; then
   if [ "$BRANCH" = "main" ]; then echo "対象なし: 主 worktree の main にいるため削除対象がありません。"; exit 0; fi
   git checkout main
   git branch -D "$BRANCH"
+  git pull --ff-only origin main
 else
   WORKTREE_PATH=$(git rev-parse --show-toplevel)
   MAIN_PATH=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
   cd "$MAIN_PATH"
   git worktree remove "$WORKTREE_PATH"
   git branch -D "$BRANCH"
+  git fetch origin
 fi
-git fetch origin
 ```
 
 ## Steps (Reference)
@@ -63,7 +64,7 @@ git fetch origin
 If the current worktree is the primary worktree (the main clone):
 
 1. If the current branch is `main` → display `対象なし: 主 worktree の main にいるため削除対象がありません。` and exit. Do not touch any other branch or worktree.
-2. Otherwise → `git checkout main`, then `git branch -D <working branch>`.
+2. Otherwise → `git checkout main`, then `git branch -D <working branch>`, then `git pull --ff-only origin main` to fast-forward the local `main` to `origin/main`. If the local `main` has unexpected commits ahead of `origin/main`, `--ff-only` causes the pull to fail so the user notices.
 
 ### Step 2B: Linked Worktree
 
@@ -78,8 +79,8 @@ If the current worktree is a linked worktree:
 
 ### Step 3: Refresh Remote Refs
 
-1. Run `git fetch origin` to update remote-tracking refs.
-2. The primary worktree's `main` working copy is **not** fast-forwarded automatically — the user updates it when they next switch to that worktree.
+- **Primary worktree branch**: the local `main` working copy is already fast-forwarded to `origin/main` by Step 2A's `git pull --ff-only origin main`.
+- **Linked worktree branch**: run `git fetch origin` to update remote-tracking refs only. The primary worktree's checked-out branch (which may or may not be `main`) is **not** touched — the user updates it when they next switch to that worktree.
 
 ### Step 4: Display Results
 


### PR DESCRIPTION
## Summary
- `/git-branch-cleanup` を primary worktree から実行した際、`git checkout main` 後にローカル `main` が `origin/main` に追従されず古いまま残る不具合を修正
- primary 分岐の末尾に `git pull --ff-only origin main` を追加。`--ff-only` により想定外のローカルコミットがあれば失敗して気付けるようにする
- 末尾の `git fetch origin` は linked worktree 分岐へ移動（`git pull` は fetch を内包するため primary では不要、linked では従来通り fetch のみ）
- SKILL.md（英語マスター・日本語版）の Step 2A / Step 3 の記述を実装と整合させて更新

Closes #112

## Test plan
- [ ] primary worktree で作業ブランチを作成・切り替え後、`origin/main` を進めた状態で `/git-branch-cleanup` を実行し、ローカル `main` が `origin/main` に追従していることを確認
- [ ] linked worktree から `/git-branch-cleanup` を実行し、primary worktree の作業ブランチが pull されないこと（fetch のみ）を確認
- [ ] ローカル `main` に `origin/main` と divergent なコミットがある状態で primary worktree から実行し、`--ff-only` により失敗することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)