### PR TITLE
chore: develop マージ時に紐づく Issue を自動クローズする共通ワークフローを追加

### DIFF
--- a/.github/workflows/close-linked-issues-on-develop.yml
+++ b/.github/workflows/close-linked-issues-on-develop.yml
@@ -1,0 +1,37 @@
+name: Close Linked Issues on develop Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  issues: write
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced in PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          issues=$(printf '%s' "$PR_BODY" \
+            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u)
+          if [ -z "$issues" ]; then
+            echo "No linked issues found in PR body."
+            exit 0
+          fi
+          for n in $issues; do
+            echo "Closing issue #$n"
+            gh issue close "$n" --repo "$REPO" \
+              --comment "develop へマージされた PR #${PR_NUMBER} に基づき、この Issue を自動クローズしました。
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+          done

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The `/config-claude-sync` skill also merges shared hook entries from `hooks/shar
 
 Use the `/config-github-sync` skill to copy Issue templates, workflow files, and CI configuration templates to your repository.
 
+The shared workflows include `close-linked-issues-on-develop.yml`, which automatically closes the linked Issues (`Closes #N`, etc.) when a PR targeting `develop` is merged — covering the case GitHub's native auto-close does not handle for non-default branches. It does nothing in repositories that do not use a `develop` branch.
+
 ## Available Skills
 
 | Skill | Command | Description |

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -71,6 +71,8 @@ ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/t
 
 `/config-github-sync` スキルを使って、Issueテンプレート、ワークフローファイル、CI設定テンプレートをリポジトリにコピーする。
 
+共通ワークフローには `close-linked-issues-on-develop.yml` が含まれる。`develop` 向けの PR がマージされたとき、PR 本文の `Closes #N` 等から紐づく Issue を自動クローズする（GitHub ネイティブの自動クローズがデフォルトブランチ以外では発火しない問題を補う）。`develop` ブランチを使わないリポジトリでは何も起こらない。
+
 ## 利用可能なスキル
 
 | スキル | コマンド | 説明 |


### PR DESCRIPTION
## Summary
- `develop` 向け PR のマージ時に、PR 本文の `Closes/Fixes/Resolves #N` から紐づく Issue を自動クローズする共通ワークフロー `.github/workflows/close-linked-issues-on-develop.yml` を追加
- GitHub ネイティブの Issue 自動クローズがデフォルトブランチ以外では発火しない問題を補う（main + develop 運用向け）
- トリガーは `pull_request: closed` × `branches: [develop]`、`merged == true` ガード付き。`develop` を使わないリポジトリでは発火せず無害
- PR 本文は環境変数経由で受け取りインジェクションを回避。`permissions: issues: write` を明示
- `README.md` / `docs/ja-JP/README.md` にワークフローの目的を最小限追記

## Test plan
- [ ] `develop` 向け PR を `Closes #N` 付きでマージ → 対象 Issue が自動クローズされる
- [ ] マージされずに閉じただけの PR では発火しない（`merged == true` ガード）
- [ ] 複数 Issue（`Closes #A`, `Closes #B`）列挙時に全てクローズされる
- [ ] `config-github-sync`（Step 2）で consuming repo に配布できることを確認

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)