### PR TITLE
chore: git-issue-start に並行 worktree 判定フローを追加する

### DIFF
--- a/skills/git-issue-start/SKILL.md
+++ b/skills/git-issue-start/SKILL.md
@@ -95,10 +95,30 @@ This skill auto-detects the base branch so it works for both `main`-only reposit
    - If the title is in Japanese, convert it to English
    - Use kebab-case (lowercase English separated by hyphens)
    - Format: `<prefix><concise-description>`
-5. Create the branch directly with the generated name:
-   - Switch to the base branch: `git checkout <base>`
-   - Pull latest: `git pull --ff-only`
-   - Create and checkout branch: `git checkout -b <branch name>`
+5. Decide the work location based on the existing clone's **current branch**
+   (`git branch --show-current`). This prevents disturbing a clone that another
+   parallel agent is already working in:
+
+   - **Current branch is `main` or `develop` (the clone is idle)**: create the
+     branch directly in the existing clone (unchanged from before):
+     - Switch to the base branch: `git checkout <base>`
+     - Pull latest: `git pull --ff-only`
+     - Create and checkout branch: `git checkout -b <branch name>`
+
+   - **Current branch is anything else (the clone is occupied by other in-flight
+     work)**: do **not** touch the existing clone. Create an isolated git worktree
+     from `<base>` instead:
+     - If the project provides a worktree helper script, prefer it
+       (e.g. `scripts/dev/create_worktree.sh <issue-number> <branch name> <base>`).
+     - Otherwise: `git fetch origin`, then
+       `git worktree add ../<repo>-<issue-number> -b <branch name> origin/<base>`.
+     - The current session's cwd remains the original clone, so tell the user to
+       **open the new worktree directory and continue work there** (re-run the
+       skill / enter Plan Mode from that worktree). If the project documents a
+       parallel worktree workflow, point the user to it.
+
+   Backward compatibility: repositories whose clone always sits on `main` (or that
+   have no `develop`) always take the idle path, so behavior is unchanged for them.
 
 ### Step 5: Project-Specific Scaffold (Conditional)
 


### PR DESCRIPTION
## Summary
- `skills/git-issue-start/SKILL.md` の Step 4（ブランチ作成）を「作業場所の判定」に拡張
  - 既存 clone の現在ブランチが `main` / `develop`（アイドル）→ 従来どおり clone でブランチ作成
  - それ以外（他作業で占有中）→ clone に触れず `origin/<base>` から worktree を作成し、worktree 側での続行をユーザーに案内
- 複数リポで共有する skill のため**汎用・後方互換**を維持（現在ブランチが `main` のリポ／`develop` 非存在リポは従来挙動のまま）。worktree 補助スクリプトがあれば優先利用する旨を汎用文言で記述

並行作業時に占有中の clone を奪う事故（bulklog #345）の再発防止。bulklog 側の `create_worktree.sh` 対応は別 PR（tatsushige-i/bulklog#350）。

Refs tatsushige-i/bulklog#348

## Test plan
- [x] 差分が Step 4 のみ・他ステップ無変更（後方互換）
- [ ] アイドル経路の手順が従来と一致することをレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)