### PR TITLE
enhance: git-review-respond を引数なしで現在のブランチから PR を自動判定する

### DIFF
--- a/docs/ja-JP/skills/git-review-respond/SKILL.md
+++ b/docs/ja-JP/skills/git-review-respond/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-review-respond
 description: Respond to GitHub PR review comments - analyze, fix code, and reply to each comment
-argument-hint: "<PR number>"
+argument-hint: "[PR number]"
 ---
 
 # PR Review Comment Response Skill
@@ -13,7 +13,21 @@ GitHub PRのレビューコメントを取得・分析し、コード修正・�
 ### Step 1: PR番号の特定
 
 - `$ARGUMENTS` が数値として指定されていればそのPR番号を使用する
-- 未指定または数値でない場合、ユーザーにPR番号を尋ねる:
+- `$ARGUMENTS` が空（引数なし）の場合、現在のブランチからPRを自動判定する:
+  - `gh pr view --json number,state,headRefName,title,url`（現在のブランチに紐づくPRを解決）を実行する
+  - PRが見つかれば、それを提示してそのPR番号を使用する:
+
+    ```text
+    現在のブランチ `<branch>` の PR #XX を対象とします。
+    ```
+
+  - PRが見つからない場合（コマンドが失敗、または現在のブランチにPRがない場合）、従来どおりユーザーにPR番号を尋ねる:
+
+    ```text
+    現在のブランチからPRを検出できませんでした。対応するPRの番号を教えてください。
+    ```
+
+- `$ARGUMENTS` が指定されているが数値でない場合、ユーザーにPR番号を尋ねる:
 
   ```text
   対応するPRの番号を教えてください。

--- a/skills/git-review-respond/SKILL.md
+++ b/skills/git-review-respond/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-review-respond
 description: Respond to GitHub PR review comments - analyze, fix code, and reply to each comment
-argument-hint: "<PR number>"
+argument-hint: "[PR number]"
 ---
 
 # PR Review Comment Response Skill
@@ -13,7 +13,21 @@ Fetch and analyze GitHub PR review comments, then perform code fixes, commits, a
 ### Step 1: Determine PR Number
 
 - If `$ARGUMENTS` is specified as a number, use that PR number
-- If not specified or not a number, ask the user for the PR number:
+- If `$ARGUMENTS` is empty (no argument), infer the PR from the current branch:
+  - Run `gh pr view --json number,state,headRefName,title,url` (resolves the PR associated with the current branch)
+  - If a PR is found, announce it and use that PR number:
+
+    ```text
+    Using PR #XX associated with the current branch `<branch>`.
+    ```
+
+  - If no PR is found (the command fails, or the current branch has no PR), fall back to asking the user for the PR number:
+
+    ```text
+    Could not detect a PR from the current branch. Please provide the PR number you'd like to address.
+    ```
+
+- If `$ARGUMENTS` is specified but is not a number, ask the user for the PR number:
 
   ```text
   Please provide the PR number you'd like to address.


### PR DESCRIPTION
## Summary
- `git-review-respond` を引数なしで起動した場合、`gh pr view` で現在のブランチに紐づく PR を自動判定するようにした
- PR が見つからない場合は従来どおりユーザーに PR 番号を尋ねるフォールバックを維持
- `argument-hint` を `"<PR number>"` → `"[PR number]"` に変更し、引数が任意であることを明示
- 日本語訳（`docs/ja-JP/`）も同期

Closes #119

## Test plan
- [ ] 引数なしかつ PR が紐づくブランチで起動し、当該 PR が自動判定されること
- [ ] PR が紐づかないブランチで起動し、PR 番号の入力を求められること
- [ ] 数値引数ありの従来挙動が変わらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)