### PR TITLE
feat: PR の監視〜マージ〜整理を自動化する git-pr-finalize スキルを追加する

### DIFF
--- a/.claude/skills/git-pr-finalize
+++ b/.claude/skills/git-pr-finalize
@@ -1,0 +1,1 @@
+../../skills/git-pr-finalize

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ skills/                 # Master skill definitions — symlinked into consuming 
 ├── git-issue-create/   # Create GitHub Issue from conversation context
 ├── git-issue-start/    # Start workflow from GitHub Issue
 ├── git-pr-create/      # Create GitHub PR with analysis
+├── git-pr-finalize/    # Watch CI/review, address findings, merge, clean up
 ├── git-review-respond/ # Respond to PR review comments
 ├── tech-debt-audit-flutter/ # Audit technical debt in Flutter / Dart projects
 └── tech-debt-audit-nextjs/ # Audit technical debt in Next.js projects
@@ -58,6 +59,7 @@ ln -s ../../../shared-claude-code/skills/git-branch-cleanup .claude/skills/git-b
 ln -s ../../../shared-claude-code/skills/git-issue-create .claude/skills/git-issue-create
 ln -s ../../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
 ln -s ../../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
+ln -s ../../../shared-claude-code/skills/git-pr-finalize .claude/skills/git-pr-finalize
 ln -s ../../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond
 ln -s ../../../shared-claude-code/skills/tech-debt-audit-flutter .claude/skills/tech-debt-audit-flutter
 ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/tech-debt-audit-nextjs
@@ -83,6 +85,7 @@ The shared workflows include `close-linked-issues-on-develop.yml`, which automat
 | `git-issue-create` | `/git-issue-create` | Create Issue from conversation context (title, body, label inference, preview) |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Fetch Issue, validate labels, create branch, enter Plan Mode |
 | `git-pr-create` | `/git-pr-create` | Identify Issue, check size limits, analyze diff, create PR |
+| `git-pr-finalize` | `/git-pr-finalize [PR#]` | Watch CI/Copilot review, address findings, merge after confirmation, clean up branches |
 | `git-review-respond` | `/git-review-respond <PR#>` | Analyze review comments, fix code, reply |
 | `tech-debt-audit-flutter` | `/tech-debt-audit-flutter` | Audit technical debt in Flutter / Dart projects with prioritized report |
 | `tech-debt-audit-nextjs` | `/tech-debt-audit-nextjs` | Audit technical debt in Next.js (App Router) projects with prioritized report |

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -19,6 +19,7 @@ skills/                 # マスタースキル定義 — シンボリックリ�
 ├── git-issue-create/   # 会話コンテキストからGitHub Issueを作成
 ├── git-issue-start/    # GitHub Issueからの作業開始ワークフロー
 ├── git-pr-create/      # 分析付きGitHub PR作成
+├── git-pr-finalize/    # CI/レビュー監視・指摘対応・マージ・整理
 ├── git-review-respond/ # PRレビューコメントへの対応
 ├── tech-debt-audit-flutter/ # Flutter / Dartプロジェクトの技術的負債調査
 └── tech-debt-audit-nextjs/ # Next.jsプロジェクトの技術的負債調査
@@ -58,6 +59,7 @@ ln -s ../../../shared-claude-code/skills/git-branch-cleanup .claude/skills/git-b
 ln -s ../../../shared-claude-code/skills/git-issue-create .claude/skills/git-issue-create
 ln -s ../../../shared-claude-code/skills/git-issue-start .claude/skills/git-issue-start
 ln -s ../../../shared-claude-code/skills/git-pr-create .claude/skills/git-pr-create
+ln -s ../../../shared-claude-code/skills/git-pr-finalize .claude/skills/git-pr-finalize
 ln -s ../../../shared-claude-code/skills/git-review-respond .claude/skills/git-review-respond
 ln -s ../../../shared-claude-code/skills/tech-debt-audit-flutter .claude/skills/tech-debt-audit-flutter
 ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/tech-debt-audit-nextjs
@@ -83,6 +85,7 @@ ln -s ../../../shared-claude-code/skills/tech-debt-audit-nextjs .claude/skills/t
 | `git-issue-create` | `/git-issue-create` | 会話の文脈からIssue作成（タイトル・本文・ラベル推定・プレビュー） |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Issue取得・ラベル検証・ブランチ作成・Plan Mode移行 |
 | `git-pr-create` | `/git-pr-create` | Issue特定・規模チェック・差分分析・PR作成 |
+| `git-pr-finalize` | `/git-pr-finalize [PR#]` | CI/Copilotレビュー監視・指摘対応・確認後マージ・ブランチ整理 |
 | `git-review-respond` | `/git-review-respond <PR#>` | レビューコメント分析・コード修正・返信 |
 | `tech-debt-audit-flutter` | `/tech-debt-audit-flutter` | Flutter / Dartプロジェクトの技術的負債調査・優先度付きレポート生成 |
 | `tech-debt-audit-nextjs` | `/tech-debt-audit-nextjs` | Next.js（App Router）プロジェクトの技術的負債調査・優先度付きレポート生成 |

--- a/docs/ja-JP/skills/git-pr-finalize/SKILL.md
+++ b/docs/ja-JP/skills/git-pr-finalize/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: git-pr-finalize
+description: Finalize a GitHub PR end-to-end - watch CI and Copilot review, address findings, merge after confirmation, and clean up branches
+argument-hint: "[PR number]"
+---
+
+# PR Finalize Skill
+
+PR 作成後のワークフローを一気通貫でオーケストレーションする: CI チェックと Copilot レビューを監視し、指摘に対応し、ユーザー確認のうえマージし、ブランチを整理する。
+
+このスキルは**オーケストレーター**である。コメント対応やブランチ整理を再実装せず、既存スキルを再利用する:
+
+- **`git-review-respond`** — レビューコメントの分析・コード修正・コミット・返信
+- **`git-branch-cleanup`** — worktree スコープのローカル整理（`main`/`develop` は保護）
+
+本スキルは **監視 + 完了判定 + マージ** に徹する。
+
+## 処理手順
+
+### Step 1: PR 番号の特定
+
+- `$ARGUMENTS` が数値で指定されていれば、その PR 番号を使用する
+- `$ARGUMENTS` が空（引数なし）の場合、現在ブランチから PR を推定する:
+  - `gh pr view --json number,state,headRefName,title,url` を実行する（現在ブランチに紐づく PR を解決）
+  - PR が見つかった場合、その旨を表示してその PR 番号を使用する:
+
+    ```text
+    Using PR #XX associated with the current branch `<branch>`.
+    ```
+
+  - PR が見つからない場合（コマンド失敗、または現在ブランチに PR が無い）、ユーザーに PR 番号を尋ねる:
+
+    ```text
+    Could not detect a PR from the current branch. Please provide the PR number you'd like to finalize.
+    ```
+
+- `$ARGUMENTS` が指定されているが数値でない場合、ユーザーに PR 番号を尋ねる:
+
+  ```text
+  Please provide the PR number you'd like to finalize.
+  ```
+
+- ユーザーの回答から明確な番号を特定できない場合、エラーを表示して終了する。推測や曖昧な解釈はしない:
+
+  ```text
+  Error: Could not identify the PR number. Please specify a number.
+  ```
+
+### Step 2: PR 情報の取得とブランチ切り替え
+
+1. `gh pr view <PR number> --json state,headRefName,number,title,url,baseRefName,mergeable,mergeStateStatus` で PR 情報を取得する
+2. コマンドが失敗した場合（指定番号の PR が存在しない）:
+   - `gh issue view <PR number>` で Issue として存在するか確認し、Issue なら以下を表示して終了する:
+
+     ```text
+     Error: #XX is an Issue. Please specify a PR number.
+     ```
+
+   - Issue でもない場合、以下を表示して終了する:
+
+     ```text
+     Error: PR #XX does not exist.
+     ```
+
+3. PR の `state` を確認する:
+   - `OPEN` でない場合 → 「This PR is already closed/merged.」と警告して終了する
+4. PR の `headRefName` ブランチを checkout する:
+   - `git checkout <headRefName>` を実行する
+   - `git pull` でリモートの最新を取得する
+
+### Step 3: 監視ループ（CI + Copilot レビュー）
+
+CI チェックと Copilot レビューを同時に監視する。**両方**が落ち着く（CI 全パス かつ 未解決レビュースレッドが無い）まで、または停止条件に達するまでループを繰り返す。
+
+1. **CI チェック**: `gh pr checks <PR number>` で PR のチェックをポーリングする（`gh pr checks <PR number> --watch` でチェック確定までブロックしてもよい）。
+   - `pending` / `in_progress` は「実行中」として扱い、待機を続ける。
+   - 実行中のチェックが無くなったら、結果を **全パス** か **失敗**（いずれかが failing/error 状態）に分類する。
+
+2. **Copilot / 人間のレビュー**: GraphQL でレビュースレッドを取得し（`git-review-respond` Step 3 と同じクエリ）、対応すべきコメントを含む未解決スレッドを検出する:
+
+   ```graphql
+   query {
+     repository(owner: "{owner}", name: "{repo}") {
+       pullRequest(number: <PR number>) {
+         reviewThreads(first: 100) {
+           nodes {
+             isResolved
+             comments(first: 100) {
+               nodes {
+                 databaseId
+               }
+             }
+           }
+         }
+       }
+     }
+   }
+   ```
+
+   - 「未解決の指摘」 = `isResolved == false` の `reviewThread`。これには Copilot（`copilot-pull-request-reviewer`）と人間のレビューコメントの両方を含む。
+   - 完了判定は**未解決スレッドの有無**で行う（再レビュー依頼の有無では判定しない）。
+
+3. **ポーリング間隔 / タイムアウト**:
+   - CI は通常数分、Copilot レビューも通常数分以内に到着する。およそ **30〜60 秒**間隔でポーリングする。
+   - 監視フェーズごとに最大待機時間（例: 合計 **約 15 分**）を設ける。タイムアウト時は現在の CI とレビュー状態を表示して停止する — マージはしない。
+
+4. ループ結果で分岐する:
+   - **CI 失敗** → Step 4（CI 失敗対応）へ。
+   - **未解決レビュースレッドあり** → Step 4（レビュー指摘対応）へ。
+   - **CI 全パス かつ 未解決スレッド無し** → Step 5 へ。
+
+### Step 4: 指摘対応（条件付き）
+
+#### 4A: レビュー指摘あり
+
+- この PR に対して `git-review-respond` スキルを実行する（`/git-review-respond <PR number>`）。分析・コード修正・コミット・push・各コメントへの返信を、同スキル自身のユーザー確認ステップに従って処理する。
+- 完了後、**Step 3** に戻り再監視する（新規コミットで CI が再実行され、返信・解決でスレッド状態が更新される）。
+
+#### 4B: CI 失敗
+
+- 失敗ジョブのログを確認する（例: `gh run view <run id> --log-failed`、または `gh pr checks` のチェック詳細 URL をたどる）。
+- 失敗原因と修正方針をユーザーに提示する。
+- 最小限の修正を適用し、関連ファイルを個別に `git add <file path>` でステージし（`git add .` は使わない）、コミットして `git push` する。
+- push 後、**Step 3** に戻り再監視する。
+
+#### 停止条件
+
+無限ループせず、以下の場合は停止して報告する:
+
+- CI 失敗が自動で解消できない。
+- PR がマージ不可状態（`mergeable == CONFLICTING`、マージコンフリクト、またはブロッキングな `mergeStateStatus`）。
+- Step 3 の監視タイムアウトに達した。
+
+現在の状態を明確に表示し、次の対応はユーザーに委ねる。
+
+### Step 5: 完了判定
+
+**CI 全パス** かつ **未解決レビュースレッドが無い** ことを確認する。これを満たした場合のみマージへ進む。
+
+### Step 6: マージ（ユーザー確認必須）
+
+マージは破壊的かつ外部に影響する操作である。**マージ前に必ずユーザーへ確認する**（共有規約「PR ステータス変更は明示指示が必要」と整合）。
+
+1. マージ前サマリを提示し、明示的な承認を待つ:
+
+   ```text
+   ## Ready to Merge
+
+   PR #XX: <title>
+   <PR URL>
+
+   - CI: all passing
+   - Review threads: all resolved
+   - Base: <baseRefName>
+
+   Merge this PR? (the head branch will be deleted)
+   ```
+
+2. 承認後、`gh pr merge <PR number> --delete-branch` でマージする。
+   - マージ方式はリポジトリ設定に従う（設定された squash/merge/rebase など）。ユーザーが指定しない限り方式を強制しない。
+   - `--delete-branch` でリモートの head ブランチを削除する。base（`main`/`develop`）は決して削除しない。
+3. マージが失敗した場合（マージ不可、ブランチ保護など）、エラーを表示して停止する。
+
+### Step 7: ローカル整理
+
+`git-branch-cleanup` スキル（`/git-branch-cleanup`）を実行し、ローカルの worktree と作業ブランチを整理する。
+
+- 主クローンと linked worktree の双方を扱い、`main`/`develop` を保護する。
+- マージ済み PR の `baseRefName` から戻り先を解決するため、PR が対象としたブランチへ戻る。
+
+### Step 8: 完了サマリ
+
+完了結果を以下の形式で表示する:
+
+```text
+## PR Finalized
+
+PR #XX: <title>
+<PR URL>
+
+- Merge: <merged | not merged (reason)>
+- Findings addressed: <summary, e.g., "2 review rounds, 1 CI fix" or "none">
+- Remote branch: <deleted | n/a>
+- Local cleanup: <summary from git-branch-cleanup>
+```

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,6 +10,7 @@ Shared skills distributed to consuming repositories via symlinks. Each skill is 
 | `git-issue-create` | `/git-issue-create` | Create Issue from conversation context (title, body, label inference, preview) |
 | `git-issue-start` | `/git-issue-start <Issue#>` | Fetch Issue, validate labels, create branch, enter Plan Mode |
 | `git-pr-create` | `/git-pr-create` | Identify Issue, check size limits, analyze diff, create PR |
+| `git-pr-finalize` | `/git-pr-finalize [PR#]` | Watch CI/Copilot review, address findings, merge after confirmation, clean up branches |
 | `git-review-respond` | `/git-review-respond <PR#>` | Analyze review comments, fix code, reply |
 | `tech-debt-audit-flutter` | `/tech-debt-audit-flutter` | Audit technical debt in Flutter / Dart projects with prioritized report |
 | `tech-debt-audit-nextjs` | `/tech-debt-audit-nextjs` | Audit technical debt in Next.js (App Router) projects with prioritized report |

--- a/skills/git-pr-finalize/SKILL.md
+++ b/skills/git-pr-finalize/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: git-pr-finalize
+description: Finalize a GitHub PR end-to-end - watch CI and Copilot review, address findings, merge after confirmation, and clean up branches
+argument-hint: "[PR number]"
+---
+
+# PR Finalize Skill
+
+Orchestrate the post-PR workflow end-to-end: watch CI checks and Copilot review, address findings, merge after user confirmation, and clean up branches.
+
+This skill is an **orchestrator**. It does not re-implement comment handling or branch cleanup; it reuses existing skills:
+
+- **`git-review-respond`** — analyze review comments, fix code, commit, and reply
+- **`git-branch-cleanup`** — worktree-scoped local cleanup (`main`/`develop` protected)
+
+The skill focuses on **monitoring + completion judgment + merge** only.
+
+## Steps
+
+### Step 1: Determine PR Number
+
+- If `$ARGUMENTS` is specified as a number, use that PR number
+- If `$ARGUMENTS` is empty (no argument), infer the PR from the current branch:
+  - Run `gh pr view --json number,state,headRefName,title,url` (resolves the PR associated with the current branch)
+  - If a PR is found, announce it and use that PR number:
+
+    ```text
+    Using PR #XX associated with the current branch `<branch>`.
+    ```
+
+  - If no PR is found (the command fails, or the current branch has no PR), fall back to asking the user for the PR number:
+
+    ```text
+    Could not detect a PR from the current branch. Please provide the PR number you'd like to finalize.
+    ```
+
+- If `$ARGUMENTS` is specified but is not a number, ask the user for the PR number:
+
+  ```text
+  Please provide the PR number you'd like to finalize.
+  ```
+
+- If a clear number cannot be determined from the user's response, exit with an error. Do not guess or make ambiguous interpretations:
+
+  ```text
+  Error: Could not identify the PR number. Please specify a number.
+  ```
+
+### Step 2: Fetch PR Information and Switch Branch
+
+1. Fetch PR information with `gh pr view <PR number> --json state,headRefName,number,title,url,baseRefName,mergeable,mergeStateStatus`
+2. If the command fails (no PR exists for the given number):
+   - Check if it exists as an Issue with `gh issue view <PR number>`, and if it's an Issue, display the following and exit:
+
+     ```text
+     Error: #XX is an Issue. Please specify a PR number.
+     ```
+
+   - If it's not an Issue either, display the following and exit:
+
+     ```text
+     Error: PR #XX does not exist.
+     ```
+
+3. Check the PR's `state`:
+   - If not `OPEN` → warn with "This PR is already closed/merged." and exit
+4. Checkout the PR's `headRefName` branch:
+   - Run `git checkout <headRefName>`
+   - Pull the latest from remote with `git pull`
+
+### Step 3: Monitoring Loop (CI + Copilot Review)
+
+Monitor CI checks and Copilot review together. Repeat the loop until **both** are settled (CI all passing and no unresolved review threads), or a stop condition is hit.
+
+1. **CI checks**: Poll the PR's checks with `gh pr checks <PR number>` (you may use `gh pr checks <PR number> --watch` to block until checks settle).
+   - Treat `pending` / `in_progress` as "still running" — keep waiting.
+   - When no running checks remain, classify the result as **all passing** or **failure** (any check in a failing/error state).
+
+2. **Copilot / human review**: Fetch review threads via GraphQL (same query as `git-review-respond` Step 3) and detect unresolved threads with actionable comments:
+
+   ```graphql
+   query {
+     repository(owner: "{owner}", name: "{repo}") {
+       pullRequest(number: <PR number>) {
+         reviewThreads(first: 100) {
+           nodes {
+             isResolved
+             comments(first: 100) {
+               nodes {
+                 databaseId
+               }
+             }
+           }
+         }
+       }
+     }
+   }
+   ```
+
+   - "Unresolved finding" = a `reviewThread` with `isResolved == false`. This includes Copilot (`copilot-pull-request-reviewer`) and human review comments.
+   - Completion judgment uses **the presence of unresolved threads** (not re-review requests).
+
+3. **Polling interval / timeout**:
+   - CI typically takes a few minutes; Copilot review typically arrives within a few minutes. Poll at roughly **30–60 second** intervals.
+   - Apply a maximum wait (e.g., **~15 minutes** total) per monitoring phase. On timeout, display the current CI and review state and stop — do not merge.
+
+4. Branch on the loop result:
+   - **CI failure** → go to Step 4 (CI failure handling).
+   - **Unresolved review threads present** → go to Step 4 (review finding handling).
+   - **CI all passing AND no unresolved threads** → go to Step 5.
+
+### Step 4: Address Findings (Conditional)
+
+#### 4A: Review findings present
+
+- Run the `git-review-respond` skill for this PR (`/git-review-respond <PR number>`). It handles analysis, code fixes, commit, push, and per-comment replies, following its own user-confirmation step.
+- After it completes, return to **Step 3** and re-monitor (new commits trigger CI again, and replies/resolutions update thread state).
+
+#### 4B: CI failure
+
+- Inspect the failing job logs (e.g., `gh run view <run id> --log-failed`, or follow the check details URL from `gh pr checks`).
+- Present the failure cause and a fix approach to the user.
+- Apply the minimum fix, stage related files individually with `git add <file path>` (do not use `git add .`), commit, and `git push`.
+- After pushing, return to **Step 3** and re-monitor.
+
+#### Stop conditions
+
+Stop and report (do not loop indefinitely) when:
+
+- A CI failure cannot be resolved automatically.
+- The PR is in a non-mergeable state (`mergeable == CONFLICTING`, merge conflicts, or a blocking `mergeStateStatus`).
+- The monitoring timeout from Step 3 is reached.
+
+Display the current state clearly and let the user decide next steps.
+
+### Step 5: Completion Judgment
+
+Confirm that **CI is all passing** and **there are no unresolved review threads**. Only then proceed to merge.
+
+### Step 6: Merge (User Confirmation Required)
+
+Merging is a destructive, outward-facing action. **Always confirm with the user before merging** (consistent with the shared conventions: PR status changes require explicit instruction).
+
+1. Present a pre-merge summary and wait for explicit approval:
+
+   ```text
+   ## Ready to Merge
+
+   PR #XX: <title>
+   <PR URL>
+
+   - CI: all passing
+   - Review threads: all resolved
+   - Base: <baseRefName>
+
+   Merge this PR? (the head branch will be deleted)
+   ```
+
+2. After approval, merge with `gh pr merge <PR number> --delete-branch`.
+   - The merge method follows the repository's settings (e.g., squash/merge/rebase as configured). Do not force a method unless the user specifies one.
+   - `--delete-branch` removes the remote head branch. The base (`main`/`develop`) is never deleted.
+3. If the merge fails (e.g., not mergeable, branch protection), display the error and stop.
+
+### Step 7: Local Cleanup
+
+Run the `git-branch-cleanup` skill (`/git-branch-cleanup`) to clean up the local worktree and working branch.
+
+- It handles both the primary clone and linked worktrees, and protects `main`/`develop`.
+- It resolves the return target from the merged PR's `baseRefName`, so it returns to whichever branch the PR targeted.
+
+### Step 8: Completion Summary
+
+Display the results in the following format:
+
+```text
+## PR Finalized
+
+PR #XX: <title>
+<PR URL>
+
+- Merge: <merged | not merged (reason)>
+- Findings addressed: <summary, e.g., "2 review rounds, 1 CI fix" or "none">
+- Remote branch: <deleted | n/a>
+- Local cleanup: <summary from git-branch-cleanup>
+```


### PR DESCRIPTION
## Summary
- PR 作成後の「CI/Copilot レビュー監視 → 指摘対応 → 確認後マージ → ブランチ整理」を一気通貫で行うオーケストレーションスキル `git-pr-finalize` を追加
- 指摘対応は `git-review-respond`、ローカル整理は `git-branch-cleanup` を再利用し、本スキルは「監視 + 完了判定 + マージ」に徹する（重複実装なし）
- マージは破壊的操作のため**マージ前に必ずユーザー確認**を挟む（conventions.md と整合）
- 完了判定は GraphQL `reviewThreads.isResolved` による**未解決スレッドの有無** + CI 全パスで判定（`git-review-respond` と同じクエリ）
- 共有スキル追加手順に準拠: マスター SKILL.md（英語）・シンボリックリンク・`skills/README.md`・日本語翻訳・ルート README（英/日）の Structure/インストール/一覧を更新

Closes #121

## Test plan
- [ ] `/local-docs-validate` 相当のチェック（シンボリックリンク・README 記載・日本語翻訳）が全スキルでパスすること
- [ ] `.claude/skills/git-pr-finalize` が `../../skills/git-pr-finalize` を指し解決すること
- [ ] frontmatter の `name` がディレクトリ名・README 記載と一致し命名規約に適合すること
- [ ] 英語マスターと `docs/ja-JP/` 翻訳の Step 構成が一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)