### PR TITLE
fix: git-branch-cleanup の cd 失敗時に worktree 自己削除を防ぐ

### DIFF
--- a/skills/git-branch-cleanup/SKILL.md
+++ b/skills/git-branch-cleanup/SKILL.md
@@ -47,7 +47,8 @@ if [ "$GITDIR" = "$COMMONDIR" ]; then
 else
   WORKTREE_PATH=$(git rev-parse --show-toplevel)
   MAIN_PATH=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
-  cd "$MAIN_PATH"
+  if [ -z "$MAIN_PATH" ] || [ ! -d "$MAIN_PATH" ]; then echo "エラー: 主 worktree のパスを解決できません ($MAIN_PATH)。"; exit 1; fi
+  cd "$MAIN_PATH" || { echo "エラー: 主 worktree への移動に失敗しました ($MAIN_PATH)。"; exit 1; }
   git worktree remove "$WORKTREE_PATH"
   git branch -D "$BRANCH"
   git fetch origin
@@ -79,7 +80,7 @@ If the current worktree is a linked worktree:
 
 1. Capture the worktree path with `git rev-parse --show-toplevel`.
 2. Capture the primary worktree path from the first `worktree` line of `git worktree list --porcelain`.
-3. `cd` into the primary worktree.
+3. Validate that the primary worktree path is non-empty and exists, then `cd` into it. If the path is invalid or the `cd` fails, abort immediately — never proceed to `git worktree remove` while the CWD is still inside the worktree being removed, or it will delete the current worktree from the inside and leave the branch undeleted.
 4. `git worktree remove <linked worktree path>` to remove the worktree directory.
 5. `git branch -D <working branch>` to delete the branch.
 6. Other linked worktrees and their branches are left alone.


### PR DESCRIPTION
## Summary
- `skills/git-branch-cleanup/SKILL.md` の linked worktree 削除フローで、`cd "$MAIN_PATH"` 失敗時も処理が止まらず `git worktree remove` に到達し、CWD が削除対象 worktree 内のまま自己削除→ブランチ削除漏れに至る問題を修正
- `MAIN_PATH` の非空・ディレクトリ存在を検証し、`cd` 失敗を明示的に致命化（`|| exit 1`）して、worktree remove 前に確実に中断
- リファレンス節（Step 2B）にも検証と中断の意図を追記

Closes #123

## Test plan
- [x] 正常系（MAIN_PATH 正常）の挙動は不変であることを確認
- [ ] MAIN_PATH が不正値の場合、`git worktree remove` を実行せずエラー終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)