### PR TITLE
enhance: git-review-respond で返信後のレビュースレッドを自動 Resolve する

### DIFF
--- a/docs/ja-JP/skills/git-review-respond/SKILL.md
+++ b/docs/ja-JP/skills/git-review-respond/SKILL.md
@@ -69,7 +69,7 @@ GitHub PRのレビューコメントを取得・分析し、コード修正・�
    gh api repos/{owner}/{repo}/pulls/<PR番号>/comments --paginate
    ```
 
-2. GraphQL APIで解決済み（resolved）スレッドのコメントIDを取得:
+2. GraphQL APIでレビュースレッドを取得（スレッドレベルのノードID含む）:
 
    ```graphql
    query {
@@ -77,6 +77,7 @@ GitHub PRのレビューコメントを取得・分析し、コード修正・�
        pullRequest(number: <PR番号>) {
          reviewThreads(first: 100) {
            nodes {
+             id
              isResolved
              comments(first: 100) {
                nodes {
@@ -89,6 +90,8 @@ GitHub PRのレビューコメントを取得・分析し、コード修正・�
      }
    }
    ```
+
+   **注記**: スレッドレベルの `id` フィールド（GraphQL node ID）を抽出し、後でスレッド解決に使用するためのマッピング `{コメントdatabaseId → スレッドId}` を作成する。
 
 3. 以下のコメントを除外:
    - `in_reply_to_id` が設定されているコメント（返信コメント）
@@ -187,18 +190,37 @@ PR #XX: <タイトル>
 
 **注意**: 「要修正」コメントがなくコード変更がない場合、このステップはスキップする。
 
-### Step 9: コメント返信
+### Step 9: コメント返信とスレッド解決
 
 Step 5 で承認された返信ドラフトをそのまま使用する。Step 6 の実際の修正内容が当初の方針から乖離した場合のみ調整する。
 
-各コメントに対して `gh api` で返信する。返信は元のコメントと同じスレッドに投稿する:
+各コメントに対して以下を実施する:
 
-```bash
-gh api repos/{owner}/{repo}/pulls/<PR番号>/comments \
-  -method POST \
-  -f body="<返信内容>" \
-  -F in_reply_to=<元コメントのID>
-```
+1. **返信を投稿** - `gh api` で返信する。返信は元のコメントと同じスレッドに投稿する:
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<PR番号>/comments \
+     -method POST \
+     -f body="<返信内容>" \
+     -F in_reply_to=<元コメントのID>
+   ```
+
+2. **スレッドを解決** - 返信投稿直後に、GraphQL mutation でスレッドを解決する:
+
+   ```bash
+   gh api graphql -f query='
+     mutation {
+       resolveReviewThread(input: {threadId: "<スレッドのnode ID>"}) {
+         thread {
+           isResolved
+         }
+       }
+     }
+   '
+   ```
+
+   - Step 3 で抽出したスレッドのnode ID（GraphQLクエリの `id` フィールド）を使用する
+   - mutationに失敗した場合は警告をログして続行する（返信は既に投稿されているため、スレッドは手動で解決可能）
 
 返信内容のガイドライン:
 
@@ -239,6 +261,9 @@ PR #XX: <タイトル>
 - 説明返信: X件
 - 対応不要: X件
 - スキップ: X件（理由: ファイル削除済みなど）
+- 解決済みスレッド: X件
 
 コミット: <コミットハッシュ>
 ```
+
+**注記**: 返信が投稿されたすべてのスレッドは Step 9 の GraphQL mutation で自動的に解決される。カウントは正常に解決されたスレッド数を表す。

--- a/skills/git-review-respond/SKILL.md
+++ b/skills/git-review-respond/SKILL.md
@@ -69,7 +69,7 @@ Fetch and analyze GitHub PR review comments, then perform code fixes, commits, a
    gh api repos/{owner}/{repo}/pulls/<PR number>/comments --paginate
    ```
 
-2. Fetch resolved thread comment IDs via GraphQL API:
+2. Fetch review threads via GraphQL API, including thread-level node IDs:
 
    ```graphql
    query {
@@ -77,6 +77,7 @@ Fetch and analyze GitHub PR review comments, then perform code fixes, commits, a
        pullRequest(number: <PR number>) {
          reviewThreads(first: 100) {
            nodes {
+             id
              isResolved
              comments(first: 100) {
                nodes {
@@ -89,6 +90,8 @@ Fetch and analyze GitHub PR review comments, then perform code fixes, commits, a
      }
    }
    ```
+
+   **Note**: Extract the `id` field at the thread level (the GraphQL node ID, not the database ID). Build a mapping: `{commentDatabaseId → threadId}` for later thread resolution.
 
 3. Exclude the following comments:
    - Comments with `in_reply_to_id` set (reply comments)
@@ -187,18 +190,37 @@ If any check fails, fix the issue and re-run.
 
 **Note**: If there are no "Needs fix" comments and no code changes, skip this step.
 
-### Step 9: Reply to Comments
+### Step 9: Reply to Comments and Resolve Threads
 
 Use the reply drafts approved in Step 5. Adjust only if the actual fix in Step 6 diverged from the planned approach.
 
-Reply to each comment using `gh api`. Post replies in the same thread as the original comment:
+For each comment, perform the following:
 
-```bash
-gh api repos/{owner}/{repo}/pulls/<PR number>/comments \
-  -method POST \
-  -f body="<reply body>" \
-  -F in_reply_to=<original comment ID>
-```
+1. **Post the reply** using `gh api`. Post replies in the same thread as the original comment:
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<PR number>/comments \
+     -method POST \
+     -f body="<reply body>" \
+     -F in_reply_to=<original comment ID>
+   ```
+
+2. **Resolve the thread** immediately after posting the reply:
+
+   ```bash
+   gh api graphql -f query='
+     mutation {
+       resolveReviewThread(input: {threadId: "<thread node ID>"}) {
+         thread {
+           isResolved
+         }
+       }
+     }
+   '
+   ```
+
+   - Use the thread node ID extracted in Step 3 (the `id` field from the GraphQL `reviewThreads` query)
+   - If the mutation fails, log a warning but continue (the reply is already posted; thread can be resolved manually if needed)
 
 Reply content guidelines:
 
@@ -239,6 +261,9 @@ PR #XX: <title>
 - Explained: X
 - No action needed: X
 - Skipped: X (reason: file deleted, etc.)
+- Resolved threads: X
 
 Commit: <commit hash>
 ```
+
+**Note**: All replied-to threads are automatically resolved via GraphQL mutation in Step 9. The count reflects the number of threads successfully resolved.


### PR DESCRIPTION
## Summary
- Step 3: GraphQL クエリを拡張してスレッドレベルの node ID を取得
- Step 9: 返信投稿後に `resolveReviewThread` mutation を実行
- Step 10: 完了サマリーに解決済みスレッド数を追加

これにより `git-pr-finalize` の未解決スレッド確認が自動でパスするようになる。

Closes #125

## Test plan
- [ ] `git-review-respond` スキルでレビューコメントに返信
- [ ] GitHub web UI で対象スレッドが Resolved に変わることを確認
- [ ] `git-pr-finalize` が未解決スレッドなしで進行することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)