### PR TITLE
enhance: base 自動判定スキルを release ブランチ運用に対応

### DIFF
--- a/docs/ja-JP/skills/git-branch-cleanup/SKILL.md
+++ b/docs/ja-JP/skills/git-branch-cleanup/SKILL.md
@@ -22,7 +22,7 @@ PR マージ後に **現在の worktree** と **そこで checkout している�
 - **全操作を 1 つの Bash tool call のコマンドチェーンで実行する。Bash tool call を分割してはならない**
 - `gh pr view`, `git checkout <home>`, `git worktree remove`, `git branch -D`, `git fetch origin`, `git pull --ff-only origin <home>` はすべて事前承認済みの操作として扱う
 - ステップ間で「実行してよいですか？」「続行しますか？」等の質問を挟まない
-- エラーが発生した場合、または「対象なし（現在ブランチが保護対象の `main`/`develop`）」を検出した場合のみ停止する
+- エラーが発生した場合、または「対象なし（現在ブランチが保護対象の `main`/`develop`/`release/*`）」を検出した場合のみ停止する
 
 ## 実行コマンド
 
@@ -33,9 +33,10 @@ set -e
 STATUS=$(git status --porcelain)
 if [ -n "$STATUS" ]; then echo "エラー: 未コミットの変更があります。"; exit 1; fi
 BRANCH=$(git branch --show-current)
-if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "develop" ]; then
-  echo "対象なし: $BRANCH は保護ブランチのため削除対象がありません。"; exit 0
-fi
+case "$BRANCH" in
+  main|develop|release/*)
+    echo "対象なし: $BRANCH は保護ブランチのため削除対象がありません。"; exit 0 ;;
+esac
 HOME=$(gh pr view "$BRANCH" --json baseRefName -q .baseRefName 2>/dev/null || true)
 if [ -z "$HOME" ]; then HOME=main; fi
 GITDIR=$(git rev-parse --git-dir)
@@ -54,7 +55,7 @@ else
 fi
 ```
 
-戻り先（`HOME`）はマージ済み PR の `baseRefName` を `gh pr view` で取得して確定するため、PR が対象としたブランチ（`main` または `develop`）に戻る。PR が見つからない場合は `main` にフォールバックする。`main` と `develop` の両方を保護対象とし、現在ブランチがいずれかの場合は「対象なし」を表示して何も削除しない。
+戻り先（`HOME`）はマージ済み PR の `baseRefName` を `gh pr view` で取得して確定するため、PR が対象としたブランチ（`main`・`develop`・`release/*` ブランチ）に戻る。PR が見つからない場合は `main` にフォールバックする。`main`・`develop`・`release/*` を保護対象とし、現在ブランチがいずれかの場合は「対象なし」を表示して何も削除しない。マージ済み `release/*` ブランチの削除は本スキルではなくリリースフロー側の責務とする。
 
 ## 処理手順（参考）
 
@@ -63,7 +64,7 @@ fi
 1. 現在の worktree で `git status --porcelain` を実行し、未コミット変更を確認する
    - 変更がある場合 → エラーを表示して終了する
 2. `git branch --show-current` で作業ブランチ名を保持する
-3. 現在ブランチが `main` または `develop` → `対象なし: <ブランチ> は保護ブランチのため削除対象がありません。` を表示して終了する。両方とも保護対象で、削除しない。
+3. 現在ブランチが `main`・`develop`・`release/*` のいずれか → `対象なし: <ブランチ> は保護ブランチのため削除対象がありません。` を表示して終了する。いずれも保護対象で削除しない。マージ済み `release/*` ブランチの削除はリリースフロー側の責務とする。
 4. マージ済み PR の base から戻り先（`HOME`）を `gh pr view <作業ブランチ> --json baseRefName -q .baseRefName` で確定する。PR が見つからない場合は `main` にフォールバックする。
 5. `git rev-parse --git-dir` と `git rev-parse --git-common-dir` を比較して、現在の worktree が **主 worktree（メインクローン）** か **linked worktree** かを判定する（一致 → 主、不一致 → linked）
 

--- a/docs/ja-JP/skills/git-issue-start/SKILL.md
+++ b/docs/ja-JP/skills/git-issue-start/SKILL.md
@@ -65,21 +65,23 @@ GitHub Issueの情報取得・ラベル検証・ブランチ作成・Plan Mode�
 
 ### Step 4: base ブランチとプレフィックスの決定
 
-このスキルは base ブランチを自動判定し、`main` のみのリポジトリ（後方互換）でも `main` + `develop`（git-flow ライト）のリポジトリでも動作する。
+このスキルは base ブランチを自動判定し、`main` のみのリポジトリ（後方互換）でも、`main` + `develop`（git-flow ライト）のリポジトリでも、`release/*` ブランチを持つリポジトリ（標準 Git Flow）でも動作する。
 
-1. `origin` に `develop` ブランチがあるか検出する:
-   - `git ls-remote --heads origin develop` を実行する
-   - 出力が非空 → `develop` あり、空 → なし
+1. `origin` で利用可能な統合ブランチを検出する:
+   - `develop`: `git ls-remote --heads origin develop` を実行（出力が非空 → あり）
+   - `release/*`: `git ls-remote --heads origin 'release/*'` を実行（出力が非空 → 1 つ以上あり）
 
-2. base ブランチとプレフィックスを決定する:
+2. base ブランチとプレフィックスを決定する（最初に一致したルールを採用）:
 
-   | origin の `develop` | Issue に `hotfix` ラベル | base ブランチ | プレフィックス               |
-   |---------------------|--------------------------|---------------|------------------------------|
-   | なし                | （不問）                 | `main`        | 下の種類ラベル表に従う       |
-   | あり                | あり                     | `main`        | `hotfix/`                    |
-   | あり                | なし                     | `develop`     | 下の種類ラベル表に従う       |
+   | # | 条件                                                         | base ブランチ        | プレフィックス             |
+   |---|--------------------------------------------------------------|----------------------|----------------------------|
+   | 1 | Issue に `hotfix` ラベル **かつ** `develop` が存在            | `main`               | `hotfix/`                  |
+   | 2 | Issue に `release` ラベル **かつ** `release/*` が 1 つ以上存在 | 最新の `release/*`   | 下の種類ラベル表に従う     |
+   | 3 | `develop` が存在                                             | `develop`            | 下の種類ラベル表に従う     |
+   | 4 | それ以外                                                     | `main`               | 下の種類ラベル表に従う     |
 
-   `develop` が存在しない場合は従来どおりの挙動：base は `main`、`hotfix` ラベルがあっても効果はない。
+   - 最新の `release/*`（ルール 2）はバージョン番号が最大のもの: `git ls-remote --heads origin 'release/*' | sed -n 's#.*refs/heads/##p' | sort -V | tail -n 1`。
+   - 後方互換: `develop` も `release/*` も持たないリポジトリは常にルール 4（base は `main`）に落ちるため、従来どおりの挙動。`release` ラベルは `release/*` ブランチが存在しない限り効果がなく、`hotfix` ラベルは `develop` が存在しない限り効果がない。
 
 3. 種類ラベルのプレフィックス表（`hotfix/` が適用されない場合に使用）。共通開発規約（`conventions.md`）の「ブランチ命名規則」に基づく:
 

--- a/docs/ja-JP/skills/git-pr-create/SKILL.md
+++ b/docs/ja-JP/skills/git-pr-create/SKILL.md
@@ -11,12 +11,15 @@ description: Create a GitHub PR from the current branch - analyze changes, check
 
 ### Step 0: base ブランチの解決
 
-以降の処理が `main` のみのリポジトリ（後方互換）でも `main` + `develop`（git-flow ライト）のリポジトリでも動作するよう、最初に base ブランチを解決する。以降の `<base>` には解決した値を使用する。
+以降の処理が `main` のみのリポジトリ（後方互換）でも、`main` + `develop`（git-flow ライト）のリポジトリでも、`release/*` ブランチを持つリポジトリ（標準 Git Flow）でも動作するよう、最初に base ブランチを解決する。以降の `<base>` には解決した値を使用する。
 
 1. `git branch --show-current` で現在のブランチを取得する
-2. `<base>` を決定する:
+2. `<base>` を決定する（最初に一致したルールを採用）:
    - 現在のブランチが `hotfix/` で始まる → `<base>` = `main`
+   - それ以外 → 現在のブランチの派生元 `release/*` ブランチを検出する: `git ls-remote --heads origin 'release/*'` で release ブランチを列挙する。存在する場合は `git fetch origin` を実行（tip をローカルに取得）してから、各 release ブランチ `R` について `git merge-base --is-ancestor origin/<R> HEAD` を判定する。`HEAD` の祖先である（現在のブランチがそこから切られた）release ブランチのうち、`HEAD` との分岐点が最も新しい（最も近い祖先）ものを `<base>` = その release ブランチとする
    - それ以外 → `git ls-remote --heads origin develop` を実行し、`develop` があれば `<base>` = `develop`、なければ `<base>` = `main`
+
+後方互換: `HEAD` の祖先である `release/*` ブランチがなく `develop` も存在しない場合、`<base>` は従来どおり `main` にフォールバックする。
 
 ### Step 1: 前提条件の確認
 
@@ -67,7 +70,7 @@ description: Create a GitHub PR from the current branch - analyze changes, check
    | `docs/`        | `docs:`                  |
    | `chore/`       | `chore:`                 |
 
-   base に関する補足: `hotfix/` は `main`（緊急の本番修正）を対象とし、`bugfix/` やその他のプレフィックスは `develop` があれば `develop` を、なければ `main` を対象とする。base は Step 0 で解決済み。
+   base に関する補足: `hotfix/` は `main`（緊急の本番修正）を対象とし、`release/*` ブランチから切られたブランチはその release ブランチ（リリース準備・リジェクト対応）を対象とする。それ以外の `bugfix/` やその他のプレフィックスは `develop` があれば `develop` を、なければ `main` を対象とする。base は Step 0 で解決済み。
 
 ### Step 5: ドキュメント整合性チェック
 

--- a/skills/git-branch-cleanup/SKILL.md
+++ b/skills/git-branch-cleanup/SKILL.md
@@ -22,7 +22,7 @@ All operations are pre-approved when the user explicitly runs `/git-branch-clean
 - **Execute all operations in a single Bash tool call command chain. Never split into multiple Bash tool calls**
 - Treat `gh pr view`, `git checkout <home>`, `git worktree remove`, `git branch -D`, `git fetch origin`, and `git pull --ff-only origin <home>` as pre-approved operations
 - Do not insert confirmation prompts like "Proceed?" or "Continue?" between steps
-- Stop only when an error occurs, or when the skill detects "nothing to clean" (current branch is a protected `main`/`develop` branch)
+- Stop only when an error occurs, or when the skill detects "nothing to clean" (current branch is a protected `main`/`develop`/`release/*` branch)
 
 ## Execution Command
 
@@ -33,9 +33,10 @@ set -e
 STATUS=$(git status --porcelain)
 if [ -n "$STATUS" ]; then echo "エラー: 未コミットの変更があります。"; exit 1; fi
 BRANCH=$(git branch --show-current)
-if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "develop" ]; then
-  echo "対象なし: $BRANCH は保護ブランチのため削除対象がありません。"; exit 0
-fi
+case "$BRANCH" in
+  main|develop|release/*)
+    echo "対象なし: $BRANCH は保護ブランチのため削除対象がありません。"; exit 0 ;;
+esac
 HOME=$(gh pr view "$BRANCH" --json baseRefName -q .baseRefName 2>/dev/null || true)
 if [ -z "$HOME" ]; then HOME=main; fi
 GITDIR=$(git rev-parse --git-dir)
@@ -55,7 +56,7 @@ else
 fi
 ```
 
-The return target (`HOME`) is resolved from the merged PR's `baseRefName` via `gh pr view`, so cleanup returns to whichever branch the PR targeted (`main` or `develop`). If the PR cannot be found, it falls back to `main`. Both `main` and `develop` are protected: when the current branch is either, the skill reports "対象なし" and deletes nothing.
+The return target (`HOME`) is resolved from the merged PR's `baseRefName` via `gh pr view`, so cleanup returns to whichever branch the PR targeted (`main`, `develop`, or a `release/*` branch). If the PR cannot be found, it falls back to `main`. `main`, `develop`, and `release/*` are protected: when the current branch is any of them, the skill reports "対象なし" and deletes nothing. Deleting a merged `release/*` branch is the responsibility of the release flow, not this skill.
 
 ## Steps (Reference)
 
@@ -64,7 +65,7 @@ The return target (`HOME`) is resolved from the merged PR's `baseRefName` via `g
 1. Check for uncommitted changes in the current worktree with `git status --porcelain`
    - If changes exist → display error and exit
 2. Record the working branch with `git branch --show-current`
-3. If the current branch is `main` or `develop` → display `対象なし: <branch> は保護ブランチのため削除対象がありません。` and exit. Both are protected and never deleted.
+3. If the current branch is `main`, `develop`, or matches `release/*` → display `対象なし: <branch> は保護ブランチのため削除対象がありません。` and exit. All of them are protected and never deleted; deleting a merged `release/*` branch is the release flow's responsibility.
 4. Resolve the return target (`HOME`) from the merged PR's base with `gh pr view <working branch> --json baseRefName -q .baseRefName`. If the PR cannot be found, fall back to `main`.
 5. Detect whether the current worktree is the **primary worktree** (main clone) or a **linked worktree** by comparing `git rev-parse --git-dir` and `git rev-parse --git-common-dir` (equal → primary, differ → linked)
 

--- a/skills/git-issue-start/SKILL.md
+++ b/skills/git-issue-start/SKILL.md
@@ -65,21 +65,23 @@ Validate the following based on the "Mandatory Issue Labels" section in the shar
 
 ### Step 4: Determine Base Branch and Prefix
 
-This skill auto-detects the base branch so it works for both `main`-only repositories (backward compatible) and `main` + `develop` (git-flow lite) repositories.
+This skill auto-detects the base branch so it works for `main`-only repositories (backward compatible), `main` + `develop` (git-flow lite) repositories, and repositories with `release/*` branches (standard Git Flow).
 
-1. Detect whether `origin` has a `develop` branch:
-   - Run `git ls-remote --heads origin develop`
-   - Non-empty output → `develop` exists; empty → it does not
+1. Detect the integration branches available on `origin`:
+   - `develop`: run `git ls-remote --heads origin develop` (non-empty output → exists)
+   - `release/*`: run `git ls-remote --heads origin 'release/*'` (non-empty output → one or more exist)
 
-2. Determine the base branch and prefix:
+2. Determine the base branch and prefix (first matching rule wins):
 
-   | `develop` on origin | Issue has `hotfix` label | Base branch | Prefix                              |
-   |---------------------|--------------------------|-------------|-------------------------------------|
-   | No                  | (any)                    | `main`      | from the type-label table below     |
-   | Yes                 | Yes                      | `main`      | `hotfix/`                           |
-   | Yes                 | No                       | `develop`   | from the type-label table below     |
+   | # | Condition                                                         | Base branch            | Prefix                          |
+   |---|-------------------------------------------------------------------|------------------------|---------------------------------|
+   | 1 | Issue has `hotfix` label **and** `develop` exists                 | `main`                 | `hotfix/`                       |
+   | 2 | Issue has `release` label **and** at least one `release/*` exists | the latest `release/*` | from the type-label table below |
+   | 3 | `develop` exists                                                  | `develop`              | from the type-label table below |
+   | 4 | Otherwise                                                         | `main`                 | from the type-label table below |
 
-   When `develop` does not exist, behavior is unchanged from before: base is `main` and a `hotfix` label has no effect.
+   - The latest `release/*` (rule 2) is the highest version: `git ls-remote --heads origin 'release/*' | sed -n 's#.*refs/heads/##p' | sort -V | tail -n 1`.
+   - Backward compatibility: repositories without `develop` and without `release/*` always fall through to rule 4 (base `main`), so behavior is unchanged. A `release` label has no effect unless a `release/*` branch exists, and a `hotfix` label has no effect unless `develop` exists.
 
 3. Type-label prefix table (used unless `hotfix/` applies), based on the "Branch Naming Convention" in the shared development conventions (`conventions.md`):
 

--- a/skills/git-pr-create/SKILL.md
+++ b/skills/git-pr-create/SKILL.md
@@ -11,12 +11,15 @@ Automate the workflow for creating a GitHub PR from the current branch. Performs
 
 ### Step 0: Resolve Base Branch
 
-Resolve the base branch first so the rest of the flow works for both `main`-only repositories (backward compatible) and `main` + `develop` (git-flow lite) repositories. Use the resolved value wherever `<base>` appears below.
+Resolve the base branch first so the rest of the flow works for `main`-only repositories (backward compatible), `main` + `develop` (git-flow lite) repositories, and repositories with `release/*` branches (standard Git Flow). Use the resolved value wherever `<base>` appears below.
 
 1. Get the current branch with `git branch --show-current`
-2. Determine `<base>`:
+2. Determine `<base>` (first matching rule wins):
    - If the current branch starts with `hotfix/` → `<base>` = `main`
-   - Otherwise → run `git ls-remote --heads origin develop`; if `develop` exists → `<base>` = `develop`, else → `<base>` = `main`
+   - Else, detect a `release/*` branch the current branch was cut from: list release branches with `git ls-remote --heads origin 'release/*'`. If any exist, run `git fetch origin` (so their tips are available locally), then for each release branch `R` test `git merge-base --is-ancestor origin/<R> HEAD`. Among the release branches that are ancestors of `HEAD` (the current branch was cut from them), pick the one whose merge-base with `HEAD` is the most recent (the closest ancestor) → `<base>` = that release branch
+   - Else → run `git ls-remote --heads origin develop`; if `develop` exists → `<base>` = `develop`, else → `<base>` = `main`
+
+Backward compatibility: when no `release/*` branch is an ancestor of `HEAD` and no `develop` exists, `<base>` falls back to `main`, unchanged from before.
 
 ### Step 1: Check Prerequisites
 
@@ -67,7 +70,7 @@ Search for the Issue automatically in the following order (do not ask the user):
    | `docs/`        | `docs:`        |
    | `chore/`       | `chore:`       |
 
-   Note on base: `hotfix/` targets `main` (urgent production fixes), while `bugfix/` and the other prefixes target `develop` when it exists (otherwise `main`). The base was already resolved in Step 0.
+   Note on base: `hotfix/` targets `main` (urgent production fixes); a branch cut from a `release/*` branch targets that release branch (release preparation / reject handling); otherwise `bugfix/` and the other prefixes target `develop` when it exists (otherwise `main`). The base was already resolved in Step 0.
 
 ### Step 5: Documentation Consistency Check
 


### PR DESCRIPTION
## Summary

base ブランチを自動判定する 3 スキル（`git-issue-start` / `git-pr-create` / `git-branch-cleanup`）を、`release/*` ブランチ運用（標準 Git Flow）に**後方互換**で対応させました。

- **git-pr-create**: Step 0 で作業ブランチの派生元 `release/*` を `git merge-base --is-ancestor` により検出し、最も近い祖先 release ブランチを base に解決。Step 4 の base 補足も更新
- **git-issue-start**: Step 4 の base/prefix 判定を優先順位ルールに再構成（1. `hotfix`→main / 2. `release`→最新 `release/*` / 3. `develop` / 4. `main`）。複数 release/* は `sort -V` で最新版を自動選択
- **git-branch-cleanup**: 保護ブランチ判定を `case main|develop|release/*` に拡張。マージ済み release ブランチの削除はリリースフロー側の責務と明記
- `develop` / `release/*` を持たないリポジトリは従来挙動（base = `main`）を維持
- 日本語訳（`docs/ja-JP/skills/`）も同期

## 受け入れ基準

- [x] 3 スキルが release ブランチを base / 保護対象として正しく扱う
- [x] develop のみ・main のみのリポジトリで従来挙動が変わらない
- [x] スキルドキュメント内の base 判定ルール記述を更新する

Closes #128

## Test plan

- [ ] `git-branch-cleanup` の埋め込みスクリプトが `bash -n` 構文チェックを通る（`case` 文）
- [ ] release/* を持たないリポジトリで base = main に解決される（後方互換）
- [ ] release ブランチから切られた作業ブランチで base が当該 release に解決される

🤖 Generated with [Claude Code](https://claude.com/claude-code)