### PR TITLE
chore: nextjs CI テンプレに draft スキップと workflow_dispatch を追加

### DIFF
--- a/ci-templates/nextjs/.github/workflows/ci.yml
+++ b/ci-templates/nextjs/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   # プロジェクトで使用するNode.jsバージョン。EOLに達したら更新する。
@@ -12,6 +13,7 @@ env:
 
 jobs:
   eol-check:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
@@ -39,6 +41,7 @@ jobs:
         run: npm audit --omit=dev --audit-level=moderate
 
   lint:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
@@ -54,6 +57,7 @@ jobs:
       - run: npm run lint
 
   test:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
@@ -70,6 +74,7 @@ jobs:
 
   build:
     needs: [lint, test]
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- draft PR 中は全ジョブをスキップ (`if: github.event.pull_request.draft == false`) — 作業中の無駄な実行を排除し Actions コストを削減
- `workflow_dispatch:` を追加し、節目で手動実行可能に

Closes #131

## Test plan
- [ ] draft PR を作成して CI ジョブがスキップされることを確認
- [ ] PR を Ready 化して CI が実行されることを確認
- [ ] Actions タブから手動実行 (workflow_dispatch) できることを確認
- [ ] `push` イベント（main へのマージ）で CI が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)