### PR TITLE
chore: ci-templates に Flutter 用 CI テンプレート（test.yml）を新設する

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ skills/                 # Master skill definitions — symlinked into consuming 
 hooks/                  # Shared hook definitions — merged into consuming repos' settings.json via config-claude-sync
 └── shared-hooks.json   # Shared hooks for PreToolUse / Stop / UserPromptSubmit / etc.
 ci-templates/           # CI/config templates by language — copied to consuming repos
+├── flutter/            # Flutter template (test.yml: format / analyze / test / build_runner)
 └── nextjs/             # Next.js template (ESLint, Jest, TypeScript configs)
 .github/
 └── ISSUE_TEMPLATE/     # Issue templates (Japanese) — copied to consuming repos

--- a/ci-templates/flutter/.github/workflows/test.yml
+++ b/ci-templates/flutter/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Flutter version from .fvmrc
+        id: fvm
+        run: echo "flutter_version=$(jq -r '.flutter' .fvmrc)" >> "$GITHUB_OUTPUT"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ steps.fvm.outputs.flutter_version }}
+          channel: stable
+          cache: true
+
+      - run: flutter pub get
+
+      - name: Check formatting
+        run: dart format --set-exit-if-changed .
+
+      - run: flutter analyze
+
+      - run: flutter test
+
+      - name: Run build_runner
+        run: flutter pub run build_runner build --delete-conflicting-outputs
+
+      - name: Check no generated files changed
+        run: git diff --exit-code

--- a/docs/ja-JP/skills/config-github-sync/SKILL.md
+++ b/docs/ja-JP/skills/config-github-sync/SKILL.md
@@ -81,6 +81,7 @@ shared-claude-codeリポジトリの `.github/` 配下の共有資材（ISSUE_TE
    - `package.json` あり → Node.js 系。`dependencies.next` または `devDependencies.next` があれば **Next.js** と判定
    - `pyproject.toml` または `setup.py` あり → **Python**
    - `go.mod` あり → **Go**
+   - `pubspec.yaml` があり `flutter:` ブロックを含む → **Flutter**
    - `ci-templates/` 配下の利用可能なテンプレートディレクトリも候補として列挙する
 3. **候補を提示してユーザーに確認する**:
 
@@ -97,7 +98,7 @@ shared-claude-codeリポジトリの `.github/` 配下の共有資材（ISSUE_TE
 
    - 一致するテンプレートがない場合 → 利用可能なテンプレートを表示し、選択またはスキップを促す
 4. **選択されたテンプレートの差分を検出する**:
-   - `ci-templates/<lang>/.github/workflows/ci.yml` ↔ ローカルの `.github/workflows/ci.yml`
+   - `ci-templates/<lang>/.github/workflows/` 以下の全ファイル ↔ ローカルの `.github/workflows/` 内の同名ファイル
    - `ci-templates/<lang>/` 直下の各ファイル（`.github/` 以外）↔ ローカルのプロジェクトルートの同名ファイル
    - 各ファイルを **同一**・**差分あり**・**新規**・**ローカルのみ** に分類（Step 2 と同じ基準）
 5. **差分を提示してユーザーに確認する**:

--- a/skills/config-github-sync/SKILL.md
+++ b/skills/config-github-sync/SKILL.md
@@ -81,6 +81,7 @@ Sync shared assets under `.github/` (ISSUE_TEMPLATE, PULL_REQUEST_TEMPLATE, work
    - `package.json` present → Node.js family. If `dependencies.next` or `devDependencies.next` is found → **Next.js**
    - `pyproject.toml` or `setup.py` present → **Python**
    - `go.mod` present → **Go**
+   - `pubspec.yaml` present AND contains `flutter:` block → **Flutter**
    - List available template directories under `ci-templates/` as additional candidates
 3. **Present candidates and confirm with the user**:
 
@@ -97,7 +98,7 @@ Sync shared assets under `.github/` (ISSUE_TEMPLATE, PULL_REQUEST_TEMPLATE, work
 
    - If no matching template is found → display available templates and ask the user to choose or skip
 4. **Detect differences** for the selected template:
-   - `ci-templates/<lang>/.github/workflows/ci.yml` vs local `.github/workflows/ci.yml`
+   - Each file under `ci-templates/<lang>/.github/workflows/` vs the same filename in local `.github/workflows/`
    - Each file directly under `ci-templates/<lang>/` (non-`.github/` items) vs the same filename at the local project root
    - Categorize each file as **Identical**, **Differs**, **New**, or **Local only** (same criteria as Step 2)
 5. **Present differences and confirm with the user**:


### PR DESCRIPTION
## Summary
- `ci-templates/flutter/.github/workflows/test.yml` を新規作成
  - draft PR スキップ（`if: github.event.pull_request.draft == false`）+ `workflow_dispatch:` トリガーを追加
  - `.fvmrc` から Flutter バージョンを読み取り `subosito/flutter-action@v2` でセットアップ
  - pub get / dart format --set-exit-if-changed / flutter analyze / flutter test / build_runner build + git diff の各ステップを含む
- `config-github-sync` スキルに Flutter 検出（`pubspec.yaml` に `flutter:` ブロックが存在）を追加
- ワークフローファイルの差分比較を `ci.yml` 固定から `.github/workflows/` 以下の全ファイルへ汎用化（Flutter の `test.yml` に対応）
- README の `ci-templates/` ツリーに `flutter/` を追記

Closes #132

## Test plan
- [ ] `ci-templates/flutter/.github/workflows/test.yml` の YAML 構造が正しいことを確認
- [ ] Flutter リポで `/config-github-sync` を実行し、`pubspec.yaml` が検出されて `flutter` テンプレートが候補に表示されることを確認
- [ ] `test.yml` が `.github/workflows/` 以下のファイルとして差分検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)