### PR TITLE
chore: CI テンプレ(flutter/nextjs)をハードニングし concurrency/paths-ignore/permissions/SHA ピンを復元する

### DIFF
--- a/ci-templates/flutter/.github/workflows/test.yml
+++ b/ci-templates/flutter/.github/workflows/test.yml
@@ -3,29 +3,46 @@ name: Test
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
   pull_request:
-    branches: [main]
+    branches: [main, develop]
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
+    # draft PR ではスキップ。push / workflow_dispatch では pull_request が無く draft は
+    # null になるため、`== false` ではなく `!= true` で判定する（null != true → 実行）。
+    if: ${{ github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Read Flutter version from .fvmrc
         id: fvm
         run: echo "flutter_version=$(jq -r '.flutter' .fvmrc)" >> "$GITHUB_OUTPUT"
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ steps.fvm.outputs.flutter_version }}
           channel: stable
           cache: true
 
       - run: flutter pub get
+
+      - name: Check for vulnerable dependencies
+        run: flutter pub get --enforce-lockfile
+        continue-on-error: true
 
       - name: Check formatting
         run: dart format --set-exit-if-changed .
@@ -35,7 +52,7 @@ jobs:
       - run: flutter test
 
       - name: Run build_runner
-        run: flutter pub run build_runner build --delete-conflicting-outputs
+        run: dart run build_runner build --delete-conflicting-outputs
 
       - name: Check no generated files changed
         run: git diff --exit-code

--- a/ci-templates/nextjs/.github/workflows/ci.yml
+++ b/ci-templates/nextjs/.github/workflows/ci.yml
@@ -3,9 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   # プロジェクトで使用するNode.jsバージョン。EOLに達したら更新する。
@@ -13,13 +24,15 @@ env:
 
 jobs:
   eol-check:
-    if: github.event.pull_request.draft == false
+    # draft PR ではスキップ。push / workflow_dispatch では draft が null になるため
+    # `== false` ではなく `!= true` で判定する（null != true → 実行）。
+    if: ${{ github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -41,13 +54,13 @@ jobs:
         run: npm audit --omit=dev --audit-level=moderate
 
   lint:
-    if: github.event.pull_request.draft == false
+    if: ${{ github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -57,13 +70,13 @@ jobs:
       - run: npm run lint
 
   test:
-    if: github.event.pull_request.draft == false
+    if: ${{ github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -74,13 +87,13 @@ jobs:
 
   build:
     needs: [lint, test]
-    if: github.event.pull_request.draft == false
+    if: ${{ github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm


### PR DESCRIPTION
## Summary
- #131/#132 で draft スキップ・`workflow_dispatch` を入れた際に落ちた、コスト/安全に効く設定を両テンプレへ復元
- **concurrency(cancel-in-progress)** と **paths-ignore(`**.md`)** を復元（無駄な同時実行・md 変更での実行を抑制＝コスト削減目的に整合）
- **permissions: contents: read**（最小権限）を追加
- actions を **SHA ピン**（checkout v6.0.3 / flutter-action v2.23.0 / setup-node v4）
- flutter: `pull_request` に **develop を維持**（カバレッジ確保）、`flutter pub run build_runner` → `dart run build_runner build`（非推奨脱却）、`--enforce-lockfile` 脆弱性チェック復元
- **draft 判定バグ修正**: `== false` → `!= true`。push / workflow_dispatch では `pull_request` が無く `draft` が null となり、`== false` だとジョブが誤ってスキップされていた（＝手動実行や main への push で CI が走らない）

## 背景
コスト削減（draft-skip + workflow_dispatch + concurrency + paths-ignore）と品質/安全を**後退ゼロで両立**させるためのハードニング。消費最大の Next.js(tabimap) には concurrency/paths-ignore が特に効く。

Closes #135

## Test plan
- [x] YAML パース検証（ruby -ryaml、両テンプレ jobs 構成 OK）
- [ ] レビュアー確認：SHA ピン・concurrency・paths-ignore・permissions・draft 判定
- [ ] 後続：各消費リポ（bulklog 等）で sync 取り込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)