### PR TITLE
fix: git-pr-finalize で Copilot レビュー完了前の早期マージ判定を防ぐ

### DIFF
--- a/docs/ja-JP/skills/git-pr-finalize/SKILL.md
+++ b/docs/ja-JP/skills/git-pr-finalize/SKILL.md
@@ -76,12 +76,27 @@ CI チェックと Copilot レビューを同時に監視する。**両方**が�
    - `pending` / `in_progress` は「実行中」として扱い、待機を続ける。
    - 実行中のチェックが無くなったら、結果を **全パス** か **失敗**（いずれかが failing/error 状態）に分類する。
 
-2. **Copilot / 人間のレビュー**: GraphQL でレビュースレッドを取得し（`git-review-respond` Step 3 と同じクエリ）、対応すべきコメントを含む未解決スレッドを検出する:
+2. **Copilot / 人間のレビュー**: GraphQL でレビュー状態を取得する。ベースは `git-review-respond` Step 3 と同じクエリで、スレッドを読む前に Copilot レビューの**完了**を確認できるよう `reviewRequests` と `reviews` を追加する:
 
    ```graphql
    query {
      repository(owner: "{owner}", name: "{repo}") {
        pullRequest(number: <PR number>) {
+         reviewRequests(first: 10) {
+           nodes {
+             requestedReviewer {
+               ... on Bot { login }
+               ... on User { login }
+             }
+           }
+         }
+         reviews(first: 50) {
+           nodes {
+             state
+             author { login }
+             submittedAt
+           }
+         }
          reviewThreads(first: 100) {
            nodes {
              isResolved
@@ -97,7 +112,15 @@ CI チェックと Copilot レビューを同時に監視する。**両方**が�
    }
    ```
 
-   - 「未解決の指摘」 = `isResolved == false` の `reviewThread`。これには Copilot（`copilot-pull-request-reviewer`）と人間のレビューコメントの両方を含む。
+   - **まず Copilot レビューの完了をゲートする。** `reviewThreads` を評価する前に Copilot レビューの状態を分類する。`reviewThreads` が空でも「指摘なし」と結論づけてはならない — Copilot がまだ投稿していないだけの可能性がある:
+
+     | 状態 | 検出条件 | アクション |
+     |---|---|---|
+     | Copilot レビュー進行中 | `reviewRequests` に `copilot-pull-request-reviewer` があるが `reviews.nodes` に Copilot のエントリがない | 待機を継続（ループ続行） |
+     | Copilot レビュー完了 | `reviews.nodes` に Copilot のエントリがあり `submittedAt` が設定されている | 通常どおり `reviewThreads` を評価する |
+     | Copilot 未設定 | `reviewRequests` にも `reviews` にも Copilot が存在しない | Copilot レビューなしで進めてよいかユーザーに確認する |
+
+   - **ゲートを通過してからのみ**、未解決スレッドを検出する: 「未解決の指摘」 = `isResolved == false` の `reviewThread`。これには Copilot（`copilot-pull-request-reviewer`）と人間のレビューコメントの両方を含む。
    - 完了判定は**未解決スレッドの有無**で行う（再レビュー依頼の有無では判定しない）。
 
 3. **ポーリング間隔 / タイムアウト**:
@@ -105,9 +128,10 @@ CI チェックと Copilot レビューを同時に監視する。**両方**が�
    - 監視フェーズごとに最大待機時間（例: 合計 **約 15 分**）を設ける。タイムアウト時は現在の CI とレビュー状態を表示して停止する — マージはしない。
 
 4. ループ結果で分岐する:
+   - **Copilot レビュー進行中**（ゲート未通過） → 完了またはタイムアウトまで待機を継続する（ループ続行）。
    - **CI 失敗** → Step 4（CI 失敗対応）へ。
    - **未解決レビュースレッドあり** → Step 4（レビュー指摘対応）へ。
-   - **CI 全パス かつ 未解決スレッド無し** → Step 5 へ。
+   - **CI 全パス かつ Copilot レビューが確定（完了、または未設定でユーザー確認済み）かつ 未解決スレッド無し** → Step 5 へ。
 
 ### Step 4: 指摘対応（条件付き）
 

--- a/docs/ja-JP/skills/git-pr-finalize/SKILL.md
+++ b/docs/ja-JP/skills/git-pr-finalize/SKILL.md
@@ -82,7 +82,7 @@ CI チェックと Copilot レビューを同時に監視する。**両方**が�
    query {
      repository(owner: "{owner}", name: "{repo}") {
        pullRequest(number: <PR number>) {
-         reviewRequests(first: 10) {
+         reviewRequests(first: 20) {
            nodes {
              requestedReviewer {
                ... on Bot { login }
@@ -116,8 +116,8 @@ CI チェックと Copilot レビューを同時に監視する。**両方**が�
 
      | 状態 | 検出条件 | アクション |
      |---|---|---|
-     | Copilot レビュー進行中 | `reviewRequests` に `copilot-pull-request-reviewer` があるが `reviews.nodes` に Copilot のエントリがない | 待機を継続（ループ続行） |
-     | Copilot レビュー完了 | `reviews.nodes` に Copilot のエントリがあり `submittedAt` が設定されている | 通常どおり `reviewThreads` を評価する |
+     | Copilot レビュー進行中 | `reviewRequests` に `copilot-pull-request-reviewer` がある、**または** `reviews.nodes` の Copilot エントリの `submittedAt` が null（PENDING ドラフト） | 待機を継続（ループ続行） |
+     | Copilot レビュー完了 | `reviews.nodes` に Copilot のエントリがあり `submittedAt` が設定されている（非 null） | 通常どおり `reviewThreads` を評価する |
      | Copilot 未設定 | `reviewRequests` にも `reviews` にも Copilot が存在しない | Copilot レビューなしで進めてよいかユーザーに確認する |
 
    - **ゲートを通過してからのみ**、未解決スレッドを検出する: 「未解決の指摘」 = `isResolved == false` の `reviewThread`。これには Copilot（`copilot-pull-request-reviewer`）と人間のレビューコメントの両方を含む。

--- a/skills/git-pr-finalize/SKILL.md
+++ b/skills/git-pr-finalize/SKILL.md
@@ -82,7 +82,7 @@ Monitor CI checks and Copilot review together. Repeat the loop until **both** ar
    query {
      repository(owner: "{owner}", name: "{repo}") {
        pullRequest(number: <PR number>) {
-         reviewRequests(first: 10) {
+         reviewRequests(first: 20) {
            nodes {
              requestedReviewer {
                ... on Bot { login }
@@ -116,8 +116,8 @@ Monitor CI checks and Copilot review together. Repeat the loop until **both** ar
 
      | State | Detection | Action |
      |---|---|---|
-     | Copilot review pending | `reviewRequests` contains `copilot-pull-request-reviewer` but `reviews.nodes` has no Copilot entry | Keep waiting (continue the loop) |
-     | Copilot review complete | `reviews.nodes` contains a Copilot entry with `submittedAt` set | Proceed to evaluate `reviewThreads` normally |
+     | Copilot review pending | `reviewRequests` contains `copilot-pull-request-reviewer`, **or** `reviews.nodes` has a Copilot entry whose `submittedAt` is null (PENDING draft) | Keep waiting (continue the loop) |
+     | Copilot review complete | `reviews.nodes` contains a Copilot entry with `submittedAt` set (non-null) | Proceed to evaluate `reviewThreads` normally |
      | Copilot not configured | Neither `reviewRequests` nor `reviews` contains Copilot | Ask the user whether to proceed without Copilot review |
 
    - **Only after the gate passes**, detect unresolved threads: "Unresolved finding" = a `reviewThread` with `isResolved == false`. This includes Copilot (`copilot-pull-request-reviewer`) and human review comments.

--- a/skills/git-pr-finalize/SKILL.md
+++ b/skills/git-pr-finalize/SKILL.md
@@ -76,12 +76,27 @@ Monitor CI checks and Copilot review together. Repeat the loop until **both** ar
    - Treat `pending` / `in_progress` as "still running" — keep waiting.
    - When no running checks remain, classify the result as **all passing** or **failure** (any check in a failing/error state).
 
-2. **Copilot / human review**: Fetch review threads via GraphQL (same query as `git-review-respond` Step 3) and detect unresolved threads with actionable comments:
+2. **Copilot / human review**: Fetch review state via GraphQL. The base is the same query as `git-review-respond` Step 3, extended with `reviewRequests` and `reviews` so the loop can confirm Copilot review **completion** before reading threads:
 
    ```graphql
    query {
      repository(owner: "{owner}", name: "{repo}") {
        pullRequest(number: <PR number>) {
+         reviewRequests(first: 10) {
+           nodes {
+             requestedReviewer {
+               ... on Bot { login }
+               ... on User { login }
+             }
+           }
+         }
+         reviews(first: 50) {
+           nodes {
+             state
+             author { login }
+             submittedAt
+           }
+         }
          reviewThreads(first: 100) {
            nodes {
              isResolved
@@ -97,7 +112,15 @@ Monitor CI checks and Copilot review together. Repeat the loop until **both** ar
    }
    ```
 
-   - "Unresolved finding" = a `reviewThread` with `isResolved == false`. This includes Copilot (`copilot-pull-request-reviewer`) and human review comments.
+   - **Gate on Copilot review completion first.** Before evaluating `reviewThreads`, classify the Copilot review state. An empty `reviewThreads` is **not** sufficient to conclude "no findings" — Copilot may simply not have posted yet:
+
+     | State | Detection | Action |
+     |---|---|---|
+     | Copilot review pending | `reviewRequests` contains `copilot-pull-request-reviewer` but `reviews.nodes` has no Copilot entry | Keep waiting (continue the loop) |
+     | Copilot review complete | `reviews.nodes` contains a Copilot entry with `submittedAt` set | Proceed to evaluate `reviewThreads` normally |
+     | Copilot not configured | Neither `reviewRequests` nor `reviews` contains Copilot | Ask the user whether to proceed without Copilot review |
+
+   - **Only after the gate passes**, detect unresolved threads: "Unresolved finding" = a `reviewThread` with `isResolved == false`. This includes Copilot (`copilot-pull-request-reviewer`) and human review comments.
    - Completion judgment uses **the presence of unresolved threads** (not re-review requests).
 
 3. **Polling interval / timeout**:
@@ -105,9 +128,10 @@ Monitor CI checks and Copilot review together. Repeat the loop until **both** ar
    - Apply a maximum wait (e.g., **~15 minutes** total) per monitoring phase. On timeout, display the current CI and review state and stop — do not merge.
 
 4. Branch on the loop result:
+   - **Copilot review pending** (gate not yet passed) → keep waiting (continue the loop until completion or timeout).
    - **CI failure** → go to Step 4 (CI failure handling).
    - **Unresolved review threads present** → go to Step 4 (review finding handling).
-   - **CI all passing AND no unresolved threads** → go to Step 5.
+   - **CI all passing AND Copilot review settled (complete, or not configured and confirmed by the user) AND no unresolved threads** → go to Step 5.
 
 ### Step 4: Address Findings (Conditional)
 


### PR DESCRIPTION
## Summary
- `git-pr-finalize` Step 3 監視ループで、`reviewThreads` を評価する**前**に Copilot レビューの完了をゲートするロジックを追加
- GraphQL クエリに `reviewRequests` / `reviews`（`submittedAt` 含む）を追加し、Copilot レビューの「進行中 / 完了 / 未設定」を分類
- 空の `reviewThreads` を「指摘なし」と即断せず、CI が Copilot レビュー完了より先に終わった場合の早期マージ判定を防止
- part 4 のループ分岐に「Copilot レビュー進行中＝待機継続」を追加し、Step 5 遷移条件に「Copilot レビュー確定」を明記
- 英語マスターと日本語翻訳（`docs/ja-JP/`）を同期更新

Closes #137

## Test plan
- [ ] EN/JA 両 SKILL.md の Step 3 でクエリ・状態表・分岐ロジックが一致していることを確認
- [ ] GraphQL クエリ片の構文（`... on Bot` / `... on User` インラインフラグメント、括弧対応）を確認
- [ ] `/local-docs-validate` でドキュメント整合性に問題が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)